### PR TITLE
Add automatic conversation summarization

### DIFF
--- a/src/conversations/constants.ts
+++ b/src/conversations/constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Constants for conversation management
+ */
+
+// Timing constants (in milliseconds)
+export const SUMMARIZATION_DEFAULTS = {
+  /** Default inactivity timeout before generating summary (5 minutes) */
+  INACTIVITY_TIMEOUT_MS: 5 * 60 * 1000,
+
+  /** How often to check for conversations needing summarization */
+  CHECK_INTERVAL_MS: 30 * 1000,
+} as const;
+
+// UI constants
+export const CONVERSATION_UI = {
+  /** How many days of conversation history to show */
+  DAYS_OF_HISTORY: 7,
+
+  /** Maximum number of conversations to fetch */
+  MAX_CONVERSATIONS: 50,
+
+  /** How often to refresh conversation list (milliseconds) */
+  REFRESH_INTERVAL_MS: 30 * 1000,
+} as const;

--- a/src/conversations/services/ConversationEventProcessor.ts
+++ b/src/conversations/services/ConversationEventProcessor.ts
@@ -161,7 +161,7 @@ export class ConversationEventProcessor {
     timestamp?: number;
   } | null {
     // Check if event has ["status", "completed"] tag
-    const isCompletion = event.tags?.some((tag) => 
+    const isCompletion = event.tags?.some((tag) =>
       tag[0] === "status" && tag[1] === "completed"
     );
 

--- a/src/conversations/services/ConversationFetcher.ts
+++ b/src/conversations/services/ConversationFetcher.ts
@@ -1,0 +1,65 @@
+import { getNDK } from "@/nostr";
+import { NDKKind } from "@/nostr/kinds";
+import { aggregateConversationMetadata, type AggregatedMetadata } from "@/events/utils/metadataAggregator";
+import { CONVERSATION_UI } from "../constants";
+
+export interface ConversationData {
+  id: string;
+  title: string;
+  summary?: string;
+  lastActivity: number;
+  projectId?: string;
+}
+
+/**
+ * Service for fetching conversation data from Nostr.
+ * Separates data fetching logic from UI components.
+ */
+export class ConversationFetcher {
+  /**
+   * Fetch recent conversations with their metadata
+   */
+  static async fetchRecentConversations(): Promise<ConversationData[]> {
+    const ndk = getNDK();
+
+    // Calculate timestamp for history window
+    const daysAgo = Math.floor(Date.now() / 1000) - (CONVERSATION_UI.DAYS_OF_HISTORY * 24 * 60 * 60);
+
+    // Fetch conversation roots
+    const conversationFilter = {
+      kinds: [NDKKind.ConversationRoot],
+      since: daysAgo,
+      limit: CONVERSATION_UI.MAX_CONVERSATIONS
+    };
+    const conversationEvents = await ndk.fetchEvents(conversationFilter);
+
+    // Fetch metadata events
+    const conversationIds = Array.from(conversationEvents).map(e => e.id);
+    let metadataMap = new Map<string, AggregatedMetadata>();
+
+    if (conversationIds.length > 0) {
+      const metadataFilter = {
+        kinds: [NDKKind.EventMetadata],
+        "#e": conversationIds
+      };
+      const metadataEvents = await ndk.fetchEvents(metadataFilter);
+      metadataMap = aggregateConversationMetadata(Array.from(metadataEvents));
+    }
+
+    // Build conversation list
+    const conversations: ConversationData[] = Array.from(conversationEvents)
+      .map(event => {
+        const metadata = metadataMap.get(event.id);
+        return {
+          id: event.id,
+          title: metadata?.title || event.content?.substring(0, 50) || "Untitled",
+          summary: metadata?.summary,
+          lastActivity: (event.created_at || 0) * 1000,
+          projectId: event.tagValue("a") // Get project reference if any
+        };
+      })
+      .sort((a, b) => b.lastActivity - a.lastActivity); // Sort by most recent
+
+    return conversations;
+  }
+}

--- a/src/conversations/services/ConversationSummarizer.ts
+++ b/src/conversations/services/ConversationSummarizer.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import { NDKEventMetadata } from "@/events/NDKEventMetadata";
+import { getNDK } from "@/nostr/ndkClient";
+import { Conversation } from "@/conversations/types";
+import { ProjectContext } from "@/services/ProjectContext";
+import { llmServiceFactory } from "@/llm";
+import { configService } from "@/services";
+import { NDKKind } from "@/nostr/kinds";
+
+export class ConversationSummarizer {
+  constructor(private context: ProjectContext) {}
+
+  async summarizeAndPublish(conversation: Conversation): Promise<void> {
+    try {
+      // Get LLM configuration
+      const llmConfig = await configService.loadTenexLLMs();
+      const metadataConfig =
+        llmConfig.configurations["metadata"] ||
+        llmConfig.configurations[llmConfig.default || ""] ||
+        null;
+
+      if (!metadataConfig) {
+        console.warn("No LLM configuration available for metadata generation");
+        return;
+      }
+
+      // Create LLM service
+      const llmService = await llmServiceFactory.createService(
+        this.context.llmLogger,
+        metadataConfig.provider,
+        metadataConfig.model,
+        metadataConfig.temperature || 0.7,
+        metadataConfig.maxTokens || 1000,
+        `summarizer-${conversation.id}`,
+        "summarizer"
+      );
+
+      // Prepare conversation content
+      const conversationContent = conversation.history
+        .filter(event => event.kind !== NDKKind.EventMetadata) // Exclude metadata events
+        .map(event => {
+          const role = event.kind === NDKKind.ConversationRoot ? "User" : "Agent";
+          return `${role}: ${event.content}`;
+        })
+        .join("\n\n");
+
+      if (!conversationContent.trim()) {
+        console.log("No content to summarize for conversation", conversation.id);
+        return;
+      }
+
+      // Generate title and summary
+      const result = await llmService.generateObject({
+        messages: [
+          {
+            role: "system",
+            content: `You are a helpful assistant that generates concise titles and summaries for technical conversations.
+Generate a title (5-10 words) that captures the main topic or goal.
+Generate a summary (2-3 sentences) highlighting key decisions, progress, and current status.
+Focus on what was accomplished or discussed, not on the process.`
+          },
+          {
+            role: "user",
+            content: `Please generate a title and summary for this conversation:\n\n${conversationContent}`
+          }
+        ],
+        schema: z.object({
+          title: z.string().describe("A concise title for the conversation (5-10 words)"),
+          summary: z.string().describe("A 2-3 sentence summary of key points and progress")
+        })
+      });
+
+      // Publish metadata event
+      const ndk = getNDK();
+      const event = new NDKEventMetadata(ndk);
+      event.kind = NDKKind.EventMetadata;
+      event.setConversationId(conversation.id);
+
+      // Add metadata tags
+      if (result.title) {
+        event.tags.push(["title", result.title]);
+      }
+      if (result.summary) {
+        event.tags.push(["summary", result.summary]);
+      }
+      event.tags.push(["generated-at", Date.now().toString()]);
+      event.tags.push(["model", metadataConfig.model]);
+
+      // Sign and publish
+      if (this.context.signer) {
+        await this.context.signer.sign(event);
+        await event.publish();
+        console.log(`Published metadata for conversation ${conversation.id}: ${result.title}`);
+      } else {
+        console.warn("No signer available to publish metadata event");
+      }
+
+    } catch (error) {
+      console.error("Error generating conversation summary:", error);
+    }
+  }
+}

--- a/src/conversations/services/SummarizationTimerManager.ts
+++ b/src/conversations/services/SummarizationTimerManager.ts
@@ -1,0 +1,79 @@
+import { logger } from "@/utils/logger";
+import { configService } from "@/services";
+import { SUMMARIZATION_DEFAULTS } from "../constants";
+import type { Conversation } from "../types";
+import type { ConversationSummarizer } from "./ConversationSummarizer";
+
+/**
+ * Manages debounced timers for conversation summarization.
+ * Single Responsibility: Handle timer scheduling and cleanup.
+ */
+export class SummarizationTimerManager {
+  private timers = new Map<string, NodeJS.Timeout>();
+  private timeoutMs: number = SUMMARIZATION_DEFAULTS.INACTIVITY_TIMEOUT_MS;
+
+  constructor(private summarizer: ConversationSummarizer) {}
+
+  /**
+   * Initialize the timer manager and load configuration
+   */
+  async initialize(): Promise<void> {
+    const config = await configService.loadTenexConfig();
+    this.timeoutMs = config.summarization?.inactivityTimeout || SUMMARIZATION_DEFAULTS.INACTIVITY_TIMEOUT_MS;
+    logger.info(`[SummarizationTimerManager] Initialized with ${this.timeoutMs}ms timeout`);
+  }
+
+  /**
+   * Schedule or reschedule summarization for a conversation
+   */
+  scheduleSummarization(conversation: Conversation): void {
+    // Clear existing timer if any
+    this.clearTimer(conversation.id);
+
+    // Set new timer
+    const timer = setTimeout(async () => {
+      logger.info(`[SummarizationTimerManager] Triggering summarization for conversation ${conversation.id}`);
+      try {
+        await this.summarizer.summarizeAndPublish(conversation);
+      } catch (error) {
+        logger.error(`[SummarizationTimerManager] Failed to summarize conversation ${conversation.id}`, { error });
+      } finally {
+        this.timers.delete(conversation.id);
+      }
+    }, this.timeoutMs);
+
+    this.timers.set(conversation.id, timer);
+    logger.debug(`[SummarizationTimerManager] Scheduled summarization for conversation ${conversation.id}`);
+  }
+
+  /**
+   * Clear timer for a specific conversation
+   */
+  clearTimer(conversationId: string): void {
+    const existingTimer = this.timers.get(conversationId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.timers.delete(conversationId);
+      logger.debug(`[SummarizationTimerManager] Cleared timer for conversation ${conversationId}`);
+    }
+  }
+
+  /**
+   * Clear all timers
+   */
+  clearAllTimers(): void {
+    for (const [conversationId, timer] of this.timers.entries()) {
+      clearTimeout(timer);
+      logger.debug(`[SummarizationTimerManager] Cleared timer for conversation ${conversationId}`);
+    }
+    this.timers.clear();
+    logger.info("[SummarizationTimerManager] Cleared all timers");
+  }
+
+  /**
+   * Get number of active timers
+   */
+  getActiveTimerCount(): number {
+    return this.timers.size;
+  }
+}

--- a/src/daemon/ProjectRuntime.ts
+++ b/src/daemon/ProjectRuntime.ts
@@ -16,6 +16,7 @@ import { mcpService } from "@/services/mcp/MCPManager";
 import { installMCPServerFromEvent } from "@/services/mcp/mcpInstaller";
 import { NDKMCPTool } from "@/events/NDKMCPTool";
 import { getNDK } from "@/nostr";
+import chalk from "chalk";
 
 /**
  * Self-contained runtime for a single project.
@@ -66,6 +67,9 @@ export class ProjectRuntime {
       return;
     }
 
+    const projectTitle = this.project.tagValue("title") || "Untitled";
+    console.log(chalk.yellow(`🚀 Starting project: ${chalk.bold(projectTitle)}`));
+
     logger.info(`Starting project runtime: ${this.projectId}`, {
       title: this.project.tagValue("title"),
     });
@@ -109,8 +113,8 @@ export class ProjectRuntime {
       // Load MCP tools from project event
       await this.initializeMCPTools();
 
-      // Initialize conversation coordinator with metadata path
-      this.conversationCoordinator = new ConversationCoordinator(this.metadataPath);
+      // Initialize conversation coordinator with metadata path and context
+      this.conversationCoordinator = new ConversationCoordinator(this.metadataPath, undefined, this.context);
       await this.conversationCoordinator.initialize();
 
       // Set conversation coordinator in context
@@ -136,6 +140,10 @@ export class ProjectRuntime {
         agentCount: this.context.agents.size,
         pmPubkey: this.context.projectManager?.pubkey?.slice(0, 8),
       });
+
+      console.log(chalk.green(`✅ Project started: ${chalk.bold(projectTitle)}`));
+      console.log(chalk.gray(`   Agents: ${this.context.agents.size} | Path: ${this.projectPath}`));
+      console.log();
     } catch (error) {
       logger.error(`Failed to start project runtime: ${this.projectId}`, {
         error: error instanceof Error ? error.message : String(error),
@@ -185,6 +193,9 @@ export class ProjectRuntime {
       return;
     }
 
+    const projectTitle = this.project.tagValue("title") || "Untitled";
+    console.log(chalk.yellow(`🛑 Stopping project: ${chalk.bold(projectTitle)}`));
+
     logger.info(`Stopping project runtime: ${this.projectId}`, {
       uptime: this.startTime ? Date.now() - this.startTime.getTime() : 0,
       eventsProcessed: this.eventCount,
@@ -214,6 +225,11 @@ export class ProjectRuntime {
     this.isRunning = false;
 
     logger.info(`Project runtime stopped: ${this.projectId}`);
+
+    const uptime = this.startTime ? Math.round((Date.now() - this.startTime.getTime()) / 1000) : 0;
+    console.log(chalk.green(`✅ Project stopped: ${chalk.bold(projectTitle)}`));
+    console.log(chalk.gray(`   Uptime: ${uptime}s | Events processed: ${this.eventCount}`));
+    console.log();
   }
 
   /**

--- a/src/events/utils/metadataAggregator.ts
+++ b/src/events/utils/metadataAggregator.ts
@@ -1,0 +1,109 @@
+import type { NDKEvent } from "@nostr-dev-kit/ndk";
+import { NDKKind } from "@/nostr/kinds";
+
+export interface AggregatedMetadata {
+  conversationId: string;
+  title?: string;
+  summary?: string;
+  generatedAt?: number;
+  model?: string;
+}
+
+/**
+ * Aggregates multiple kind 513 metadata events for conversations.
+ * Uses "most recent wins per tag" strategy with fallback to older values.
+ */
+export function aggregateConversationMetadata(events: NDKEvent[]): Map<string, AggregatedMetadata> {
+  const metadataByConversation = new Map<string, AggregatedMetadata>();
+
+  // Group events by conversation ID
+  const eventsByConversation = new Map<string, NDKEvent[]>();
+  for (const event of events) {
+    if (event.kind !== NDKKind.EventMetadata) continue;
+
+    // Get conversation ID from "e" tag
+    const conversationId = event.tagValue("e");
+    if (!conversationId) continue;
+
+    if (!eventsByConversation.has(conversationId)) {
+      eventsByConversation.set(conversationId, []);
+    }
+    eventsByConversation.get(conversationId)?.push(event);
+  }
+
+  // Aggregate metadata for each conversation
+  for (const [conversationId, convEvents] of eventsByConversation) {
+    // Sort events by created_at timestamp (newest first)
+    const sortedEvents = convEvents.sort((a, b) => {
+      const timeA = a.created_at || 0;
+      const timeB = b.created_at || 0;
+      return timeB - timeA;
+    });
+
+    // Start with empty metadata
+    const aggregated: AggregatedMetadata = {
+      conversationId
+    };
+
+    // Iterate through events from newest to oldest
+    // Take the first non-empty value found for each field
+    for (const event of sortedEvents) {
+      // Title tag
+      if (!aggregated.title) {
+        const title = event.tagValue("title");
+        if (title) {
+          aggregated.title = title;
+        }
+      }
+
+      // Summary tag
+      if (!aggregated.summary) {
+        const summary = event.tagValue("summary");
+        if (summary) {
+          aggregated.summary = summary;
+        }
+      }
+
+      // Generated-at tag (use most recent)
+      if (!aggregated.generatedAt) {
+        const generatedAt = event.tagValue("generated-at");
+        if (generatedAt) {
+          aggregated.generatedAt = parseInt(generatedAt);
+        }
+      }
+
+      // Model tag (use most recent)
+      if (!aggregated.model) {
+        const model = event.tagValue("model");
+        if (model) {
+          aggregated.model = model;
+        }
+      }
+
+      // If we have all fields, we can stop
+      if (aggregated.title && aggregated.summary && aggregated.generatedAt && aggregated.model) {
+        break;
+      }
+    }
+
+    metadataByConversation.set(conversationId, aggregated);
+  }
+
+  return metadataByConversation;
+}
+
+/**
+ * Get the most recent metadata for a single conversation
+ */
+export function getLatestMetadata(events: NDKEvent[], conversationId: string): AggregatedMetadata | undefined {
+  const conversationEvents = events.filter(e =>
+    e.kind === NDKKind.EventMetadata && e.tagValue("e") === conversationId
+  );
+
+  if (conversationEvents.length === 0) {
+    return undefined;
+  }
+
+  const aggregated = aggregateConversationMetadata(conversationEvents);
+  return aggregated.get(conversationId);
+}

--- a/src/nostr/kinds.ts
+++ b/src/nostr/kinds.ts
@@ -13,6 +13,9 @@ export const NDKKind = {
     ...BaseNDKKind,
 
     // Standard NIP kinds not in NDK
+    ConversationRoot: 11, // Agent request (conversation root)
+    EventMetadata: 513, // Event metadata (titles, summaries)
+    GenericReply: 1111, // Generic reply (NOT kind 1)
     AgentRequest: 4133, // NIP-90 Agent Request
     AgentNudge: 4201, // Agent Nudge - system prompt injection
 

--- a/src/services/config/types.ts
+++ b/src/services/config/types.ts
@@ -19,7 +19,12 @@ export interface TenexConfig {
   // Logging configuration
   logging?: {
     logFile?: string; // Path to log file (default: ~/.tenex/daemon.log)
-    level?: 'silent' | 'error' | 'warn' | 'info' | 'debug'; // Log level (inherits from LOG_LEVEL env var if not set)
+    level?: "silent" | "error" | "warn" | "info" | "debug"; // Log level (inherits from LOG_LEVEL env var if not set)
+  };
+
+  // Summarization configuration
+  summarization?: {
+    inactivityTimeout?: number; // Milliseconds to wait after last activity before generating summary (default: 300000 = 5 minutes)
   };
 
   // Project fields (optional for global config)
@@ -35,7 +40,10 @@ export const TenexConfigSchema = z.object({
   relays: z.array(z.string()).optional(),
   logging: z.object({
     logFile: z.string().optional(),
-    level: z.enum(['silent', 'error', 'warn', 'info', 'debug']).optional(),
+    level: z.enum(["silent", "error", "warn", "info", "debug"]).optional(),
+  }).optional(),
+  summarization: z.object({
+    inactivityTimeout: z.number().optional(),
   }).optional(),
   description: z.string().optional(),
   repoUrl: z.string().optional(),

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,50 @@
+/**
+ * Time formatting utilities
+ */
+
+/**
+ * Format a timestamp into a human-readable "time ago" string
+ */
+export function formatTimeAgo(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+
+  if (months > 0) {
+    return `${months} month${months > 1 ? "s" : ""} ago`;
+  }
+  if (weeks > 0) {
+    return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
+  }
+  if (days > 0) {
+    return `${days} day${days > 1 ? "s" : ""} ago`;
+  }
+  if (hours > 0) {
+    return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+  }
+  if (minutes > 0) {
+    return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+  }
+  if (seconds > 30) {
+    return `${seconds} seconds ago`;
+  }
+  return "just now";
+}
+
+/**
+ * Format uptime from a start time
+ */
+export function formatUptime(startTime: Date | null): string {
+  if (!startTime) return "N/A";
+  const now = new Date();
+  const diff = now.getTime() - startTime.getTime();
+  const hours = Math.floor(diff / 3600000);
+  const minutes = Math.floor((diff % 3600000) / 60000);
+  const seconds = Math.floor((diff % 60000) / 1000);
+  return `${hours}h ${minutes}m ${seconds}s`;
+}


### PR DESCRIPTION
## Summary

- Implemented automatic conversation summarization using LLMs to generate titles and summaries
- Added `ConversationSummarizer` service that generates 5-10 word titles and 2-3 sentence summaries
- Added `SummarizationTimerManager` for debounced timer management (5-minute inactivity timeout)
- Added `ConversationFetcher` service to fetch conversations with metadata from Nostr
- Added `metadataAggregator` utility to handle multiple metadata events with "most recent wins" strategy
- Integrated summarization into `ConversationCoordinator` with proper cleanup
- Added conversation list view to Process Manager UI (toggle with 'c' and 'p' keys)
- Added configuration support for customizable inactivity timeout
- Published summaries as Nostr events (kind 513 - EventMetadata)

## Changes

- **New Services**: ConversationSummarizer, SummarizationTimerManager, ConversationFetcher
- **New Utilities**: metadataAggregator, time formatting utilities
- **Updated**: ConversationCoordinator, ProjectRuntime, ProcessManagerUI
- **Config**: Added summarization.inactivityTimeout config option
- **Constants**: Added Nostr kinds (ConversationRoot: 11, EventMetadata: 513, GenericReply: 1111)

## Test Plan

- [ ] Start the daemon and verify conversation summarization works
- [ ] Verify summaries are generated after 5 minutes of inactivity
- [ ] Test the Process Manager UI conversation view (press 'c' to switch)
- [ ] Verify conversations display with titles and summaries
- [ ] Test custom inactivity timeout configuration
- [ ] Verify proper cleanup when projects are stopped
- [ ] Check that metadata events are published correctly to Nostr

🤖 Generated with [Claude Code](https://claude.com/claude-code)