### PR TITLE
fix: address remaining worktree PR review recommendations

### DIFF
--- a/src/daemon/ProjectRuntime.ts
+++ b/src/daemon/ProjectRuntime.ts
@@ -36,6 +36,9 @@ export class ProjectRuntime {
      * Default worktree path (initial branch like master/main).
      * Example: ~/tenex/{dTag}/master
      * Used as fallback working directory when no branch is specified.
+     *
+     * Note: Not readonly because it's set to a placeholder in the constructor
+     * and updated to the actual worktree path after git initialization in start().
      */
     public defaultWorktreePath: string;
     private readonly metadataPath: string; // TENEX metadata path

--- a/src/utils/git/initializeGitRepo.ts
+++ b/src/utils/git/initializeGitRepo.ts
@@ -120,11 +120,10 @@ export async function initializeGitRepository(projectBaseDir?: string): Promise<
                 );
                 logger.info("Created worktree for existing bare repo", { worktreeDir, branchName });
             } catch {
-                // Check if worktree was created by another process
-                try {
-                    await fs.access(worktreeDir);
+                // Check if worktree was created by another process (verify it's a valid git repo, not just a directory)
+                if (await isGitRepository(worktreeDir)) {
                     logger.info("Worktree was created by another process", { worktreeDir });
-                } catch {
+                } else {
                     throw new Error(`Failed to create worktree at ${worktreeDir}`);
                 }
             }
@@ -157,11 +156,10 @@ export async function initializeGitRepository(projectBaseDir?: string): Promise<
         );
         logger.info("Created initial worktree", { worktreeDir, branchName });
     } catch {
-        // Check if worktree was created by another process
-        try {
-            await fs.access(worktreeDir);
+        // Check if worktree was created by another process (verify it's a valid git repo, not just a directory)
+        if (await isGitRepository(worktreeDir)) {
             logger.info("Worktree was created by another process", { worktreeDir });
-        } catch {
+        } else {
             throw new Error(`Failed to create worktree at ${worktreeDir}`);
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #28 - these improvements were pushed after the PR was merged.

### Changes:
- **initializeGitRepo.ts**: Use `isGitRepository()` instead of `fs.access()` for race condition handling (validates worktree is a valid git repo, not just a directory)
- **ExecutionContextFactory.ts**: Eliminate duplicate `listWorktrees()` calls by moving call before conditional
- **ExecutionContextFactory.ts**: Add warning logs for "no worktrees exist" edge case with helpful hints
- **ProjectRuntime.ts**: Document why `defaultWorktreePath` is intentionally not readonly

## Test Plan
- [x] TypeScript compilation passes