### PR TITLE
fix: use correct 'output' field from AI SDK TypedToolResult

### DIFF
--- a/src/agents/execution/AgentExecutor.ts
+++ b/src/agents/execution/AgentExecutor.ts
@@ -828,12 +828,12 @@ export class AgentExecutor {
                         if (toolResults.length > 0) {
                             messagesWithToolCalls.push({
                                 role: "tool",
-                                content: toolResults.map((tr: { toolCallId: string; toolName: string; result: unknown }) => ({
+                                content: toolResults.map((tr: { toolCallId: string; toolName: string; output: unknown }) => ({
                                     type: "tool-result" as const,
                                     toolCallId: tr.toolCallId,
                                     toolName: tr.toolName,
-                                    // AI SDK requires 'output' field, default to empty if undefined
-                                    output: tr.result !== undefined ? tr.result : { type: "text", value: "" },
+                                    // AI SDK provides 'output' field on TypedToolResult
+                                    output: tr.output !== undefined ? tr.output : { type: "text", value: "" },
                                 })),
                             });
                         }

--- a/src/agents/execution/__tests__/onstopcheck-tool-result.test.ts
+++ b/src/agents/execution/__tests__/onstopcheck-tool-result.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Test for the bug where tool results were being lost in onStopCheck
+ *
+ * Root cause: The code was accessing `tr.result` but the AI SDK provides `tr.output`
+ *
+ * In AgentExecutor.ts onStopCheck:
+ *   toolResults.map((tr: { toolCallId: string; toolName: string; result: unknown }) => ...)
+ *
+ * But AI SDK's TypedToolResult has:
+ *   { type: 'tool-result'; toolCallId: string; toolName: string; output: unknown; ... }
+ *
+ * So `tr.result` is always undefined, causing the fallback to { type: "text", value: "" }
+ */
+
+import { describe, it, expect } from "bun:test";
+
+describe("onStopCheck tool result mapping - BUG REPRODUCTION", () => {
+    // Simulating the AI SDK's TypedToolResult structure
+    interface AISDKToolResult {
+        type: "tool-result";
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+        output: unknown;  // <-- AI SDK uses 'output'
+        providerExecuted?: boolean;
+    }
+
+    // What the buggy code expected
+    interface BuggyToolResult {
+        toolCallId: string;
+        toolName: string;
+        result: unknown;  // <-- Buggy code looked for 'result'
+    }
+
+    it("should demonstrate the bug: accessing tr.result on AI SDK result gives undefined", () => {
+        // This is what the AI SDK provides
+        const aiSDKResult: AISDKToolResult = {
+            type: "tool-result",
+            toolCallId: "call_123",
+            toolName: "delegate",
+            input: { delegations: [{ recipient: "researcher", prompt: "research" }] },
+            output: {  // The actual tool output is in 'output'
+                __stopExecution: true,
+                pendingDelegations: [{ eventId: "e1", recipientPubkey: "pk1" }],
+                delegationEventIds: { pk1: "e1" },
+                message: "Delegated to researcher",
+            },
+        };
+
+        // What the buggy code does - cast to wrong type and access .result
+        const asBuggy = aiSDKResult as unknown as BuggyToolResult;
+
+        // BUG: tr.result is undefined because AI SDK uses 'output'
+        expect(asBuggy.result).toBeUndefined();
+
+        // The buggy fallback logic:
+        const buggyOutput = asBuggy.result !== undefined
+            ? asBuggy.result
+            : { type: "text", value: "" };
+
+        // This is why we see empty output!
+        expect(buggyOutput).toEqual({ type: "text", value: "" });
+    });
+
+    it("should show the fix: access tr.output instead of tr.result", () => {
+        const aiSDKResult: AISDKToolResult = {
+            type: "tool-result",
+            toolCallId: "call_123",
+            toolName: "delegate",
+            input: { delegations: [{ recipient: "researcher", prompt: "research" }] },
+            output: {
+                __stopExecution: true,
+                pendingDelegations: [{ eventId: "e1", recipientPubkey: "pk1" }],
+                delegationEventIds: { pk1: "e1" },
+                message: "Delegated to researcher",
+            },
+        };
+
+        // CORRECT: Access 'output' not 'result'
+        const correctOutput = aiSDKResult.output !== undefined
+            ? aiSDKResult.output
+            : { type: "text", value: "" };
+
+        // Now we get the actual output
+        expect(correctOutput).toEqual({
+            __stopExecution: true,
+            pendingDelegations: [{ eventId: "e1", recipientPubkey: "pk1" }],
+            delegationEventIds: { pk1: "e1" },
+            message: "Delegated to researcher",
+        });
+
+        // And it's definitely not empty
+        expect(correctOutput).not.toEqual({ type: "text", value: "" });
+    });
+
+    it("should simulate the complete fix for onStopCheck toolResult mapping", () => {
+        // Simulate the step.toolResults array from AI SDK
+        const toolResults: AISDKToolResult[] = [
+            {
+                type: "tool-result",
+                toolCallId: "call_456",
+                toolName: "delegate",
+                input: { delegations: [{ recipient: "agent", prompt: "task" }] },
+                output: {
+                    __stopExecution: true,
+                    pendingDelegations: [
+                        { eventId: "ev1", recipientPubkey: "pk1", recipientSlug: "agent", prompt: "task" }
+                    ],
+                    delegationEventIds: { pk1: "ev1" },
+                    message: "Delegated to: @agent -> ev1",
+                },
+            },
+        ];
+
+        // FIXED: Use 'output' in the type and access
+        const fixedMapping = toolResults.map((tr) => ({
+            type: "tool-result" as const,
+            toolCallId: tr.toolCallId,
+            toolName: tr.toolName,
+            output: tr.output !== undefined ? tr.output : { type: "text", value: "" },
+        }));
+
+        // Now the output is correctly preserved
+        expect(fixedMapping[0].output).toHaveProperty("__stopExecution", true);
+        expect(fixedMapping[0].output).toHaveProperty("delegationEventIds");
+        expect((fixedMapping[0].output as any).message).toBe("Delegated to: @agent -> ev1");
+    });
+});

--- a/src/agents/execution/__tests__/tool-result-preservation.test.ts
+++ b/src/agents/execution/__tests__/tool-result-preservation.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Test for tool result preservation in RAL state
+ *
+ * This test verifies that when an agent executes a tool that returns a StopExecutionSignal,
+ * the tool result is properly preserved in the RAL state messages for when the agent resumes.
+ *
+ * Bug: Tool results were being dropped/saved as empty strings when stored in RAL state.
+ * The symptom was that after resuming from a delegation, the tool result message showed:
+ * { type: "tool-result", toolName: "delegate", output: { type: "text", value: "" } }
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { RALRegistry } from "@/services/ral/RALRegistry";
+import type { PendingDelegation, StopExecutionSignal } from "@/services/ral/types";
+import type { ModelMessage } from "ai";
+
+describe("Tool Result Preservation in RAL State", () => {
+    const AGENT_PUBKEY = "test-agent-pubkey-123";
+    const CONVERSATION_ID = "test-conversation-456";
+
+    let ralRegistry: RALRegistry;
+    let ralNumber: number;
+
+    beforeEach(() => {
+        ralRegistry = RALRegistry.getInstance();
+        ralRegistry.clearAll();
+        ralNumber = ralRegistry.create(AGENT_PUBKEY, CONVERSATION_ID, "trigger-event-id");
+    });
+
+    afterEach(() => {
+        ralRegistry.clearAll();
+    });
+
+    describe("saveState with delegate tool results", () => {
+        it("should preserve the delegate tool output in messages", () => {
+            // Simulate the delegate tool return value
+            const delegateOutput: StopExecutionSignal & { delegationEventIds: Record<string, string>; message: string } = {
+                __stopExecution: true,
+                pendingDelegations: [
+                    {
+                        eventId: "delegation-event-123",
+                        recipientPubkey: "recipient-pubkey-456",
+                        recipientSlug: "researcher",
+                        prompt: "Research the topic",
+                    },
+                ],
+                delegationEventIds: {
+                    "recipient-pubkey-456": "delegation-event-123",
+                },
+                message: "Delegated to:\n@researcher -> delegation-event-123",
+            };
+
+            // Simulate the toolCalls and toolResults from AI SDK step
+            const toolCallId = "call_48046689";
+            const toolName = "delegate";
+
+            // Build messages array as done in AgentExecutor.executeStreaming onStopCheck
+            const baseMessages: ModelMessage[] = [
+                { role: "system", content: "You are a helpful assistant." },
+                { role: "user", content: "Please delegate to the researcher agent." },
+            ];
+
+            // Add assistant message with tool call
+            const messagesWithToolCalls: ModelMessage[] = [
+                ...baseMessages,
+                {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "tool-call" as const,
+                            toolCallId,
+                            toolName,
+                            input: {
+                                delegations: [
+                                    { recipient: "researcher", prompt: "Research the topic" }
+                                ]
+                            },
+                        },
+                    ],
+                },
+            ];
+
+            // Simulate what AgentExecutor does - this is the critical part
+            // Line 835-836 in AgentExecutor.ts:
+            // output: tr.result !== undefined ? tr.result : { type: "text", value: "" }
+            const toolResult = delegateOutput; // This is tr.result
+            const formattedOutput = toolResult !== undefined ? toolResult : { type: "text", value: "" };
+
+            // Add tool result message
+            const finalMessages: ModelMessage[] = [
+                ...messagesWithToolCalls,
+                {
+                    role: "tool",
+                    content: [
+                        {
+                            type: "tool-result" as const,
+                            toolCallId,
+                            toolName,
+                            output: formattedOutput,
+                        },
+                    ],
+                },
+            ];
+
+            // Save state
+            ralRegistry.saveState(
+                AGENT_PUBKEY,
+                CONVERSATION_ID,
+                ralNumber,
+                finalMessages,
+                delegateOutput.pendingDelegations
+            );
+
+            // Retrieve and verify
+            const savedMessages = ralRegistry.getMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber);
+
+            expect(savedMessages).toHaveLength(4);
+
+            // Find the tool result message
+            const toolResultMessage = savedMessages.find(m => m.role === "tool");
+            expect(toolResultMessage).toBeDefined();
+
+            const content = toolResultMessage!.content;
+            expect(Array.isArray(content)).toBe(true);
+
+            const toolResultContent = (content as any[])[0];
+            expect(toolResultContent.type).toBe("tool-result");
+            expect(toolResultContent.toolName).toBe("delegate");
+
+            // THIS IS THE CRITICAL CHECK - the output should NOT be empty
+            expect(toolResultContent.output).not.toEqual({ type: "text", value: "" });
+
+            // The output should be the original delegate output
+            expect(toolResultContent.output.__stopExecution).toBe(true);
+            expect(toolResultContent.output.delegationEventIds).toBeDefined();
+            expect(toolResultContent.output.message).toContain("Delegated to:");
+        });
+
+        it("should handle undefined tool result gracefully", () => {
+            const toolCallId = "call_undefined";
+            const toolName = "some_tool";
+
+            const baseMessages: ModelMessage[] = [
+                { role: "user", content: "Do something" },
+            ];
+
+            // Simulate undefined result (edge case)
+            const toolResult = undefined;
+            const formattedOutput = toolResult !== undefined ? toolResult : { type: "text" as const, value: "" };
+
+            const messagesWithResult: ModelMessage[] = [
+                ...baseMessages,
+                {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "tool-call" as const,
+                            toolCallId,
+                            toolName,
+                            input: {},
+                        },
+                    ],
+                },
+                {
+                    role: "tool",
+                    content: [
+                        {
+                            type: "tool-result" as const,
+                            toolCallId,
+                            toolName,
+                            output: formattedOutput,
+                        },
+                    ],
+                },
+            ];
+
+            ralRegistry.saveState(AGENT_PUBKEY, CONVERSATION_ID, ralNumber, messagesWithResult, []);
+
+            const savedMessages = ralRegistry.getMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber);
+            const toolResultMessage = savedMessages.find(m => m.role === "tool");
+
+            expect(toolResultMessage).toBeDefined();
+            const toolResultContent = (toolResultMessage!.content as any[])[0];
+
+            // For undefined results, the fallback is acceptable
+            expect(toolResultContent.output).toEqual({ type: "text", value: "" });
+        });
+    });
+
+    describe("message persistence across RAL operations", () => {
+        it("should preserve tool results through getMessages calls", () => {
+            const toolCallId = "call_persist";
+            const toolResult = { status: "success", data: { count: 42 } };
+
+            const messages: ModelMessage[] = [
+                { role: "user", content: "Get count" },
+                {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "tool-call" as const,
+                            toolCallId,
+                            toolName: "get_count",
+                            input: {},
+                        },
+                    ],
+                },
+                {
+                    role: "tool",
+                    content: [
+                        {
+                            type: "tool-result" as const,
+                            toolCallId,
+                            toolName: "get_count",
+                            output: toolResult,
+                        },
+                    ],
+                },
+            ];
+
+            ralRegistry.saveMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber, messages);
+
+            // First retrieval
+            const firstGet = ralRegistry.getMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber);
+            const firstToolResult = (firstGet.find(m => m.role === "tool")!.content as any[])[0];
+            expect(firstToolResult.output).toEqual(toolResult);
+
+            // Second retrieval (should be identical)
+            const secondGet = ralRegistry.getMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber);
+            const secondToolResult = (secondGet.find(m => m.role === "tool")!.content as any[])[0];
+            expect(secondToolResult.output).toEqual(toolResult);
+        });
+
+        it("should preserve complex nested tool outputs", () => {
+            const complexOutput = {
+                __stopExecution: true,
+                pendingDelegations: [
+                    { eventId: "e1", recipientPubkey: "pk1", recipientSlug: "agent1", prompt: "task1" },
+                    { eventId: "e2", recipientPubkey: "pk2", recipientSlug: "agent2", prompt: "task2" },
+                ],
+                delegationEventIds: { pk1: "e1", pk2: "e2" },
+                message: "Delegated to 2 agents",
+                metadata: {
+                    nested: {
+                        deeply: {
+                            value: "preserved",
+                        },
+                    },
+                    array: [1, 2, 3, { key: "val" }],
+                },
+            };
+
+            const messages: ModelMessage[] = [
+                { role: "user", content: "Delegate" },
+                {
+                    role: "assistant",
+                    content: [{ type: "tool-call" as const, toolCallId: "c1", toolName: "delegate", input: {} }],
+                },
+                {
+                    role: "tool",
+                    content: [{ type: "tool-result" as const, toolCallId: "c1", toolName: "delegate", output: complexOutput }],
+                },
+            ];
+
+            ralRegistry.saveState(AGENT_PUBKEY, CONVERSATION_ID, ralNumber, messages, []);
+
+            const retrieved = ralRegistry.getMessages(AGENT_PUBKEY, CONVERSATION_ID, ralNumber);
+            const toolOutput = (retrieved.find(m => m.role === "tool")!.content as any[])[0].output;
+
+            expect(toolOutput).toEqual(complexOutput);
+            expect(toolOutput.metadata.nested.deeply.value).toBe("preserved");
+            expect(toolOutput.metadata.array[3].key).toBe("val");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fixed bug where tool results were being dropped when saving RAL state during delegations
- The code was accessing `tr.result` but AI SDK's `TypedToolResult` uses `output` field
- Added tests to reproduce and verify the fix

## Bug Symptom
After delegation, the agent's messages showed empty tool results:
```json
{
  "type": "tool-result",
  "toolName": "delegate",
  "output": { "type": "text", "value": "" }
}
```

## Root Cause
In `AgentExecutor.ts` line 831, the code used wrong property name:
```typescript
// Before (buggy):
tr.result !== undefined ? tr.result : { type: "text", value: "" }

// After (fixed):
tr.output !== undefined ? tr.output : { type: "text", value: "" }
```

## Test plan
- [x] Added `onstopcheck-tool-result.test.ts` - reproduces the exact bug scenario
- [x] Added `tool-result-preservation.test.ts` - verifies RAL storage preserves tool results
- [x] All 7 new tests pass
- [x] All 60 RALRegistry unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)