### PR TITLE
fix: add q-tags to MCP delegation tool events

### DIFF
--- a/src/nostr/AgentPublisher.ts
+++ b/src/nostr/AgentPublisher.ts
@@ -20,6 +20,7 @@ import {
     type LessonIntent,
     type ToolUseIntent,
 } from "./AgentEventEncoder";
+import { PendingDelegationsRegistry } from "@/services/ral";
 
 /**
  * Configuration for delegation events.
@@ -277,6 +278,9 @@ export class AgentPublisher {
         await this.agent.sign(event);
         await this.safePublish(event, "delegation", parentContext);
 
+        // Register with PendingDelegationsRegistry for q-tag correlation
+        PendingDelegationsRegistry.register(this.agent.pubkey, context.conversationId, event.id);
+
         return event.id;
     }
 
@@ -362,6 +366,9 @@ export class AgentPublisher {
         await this.agent.sign(event);
         await this.safePublish(event, "ask", parentContext);
 
+        // Register with PendingDelegationsRegistry for q-tag correlation
+        PendingDelegationsRegistry.register(this.agent.pubkey, context.conversationId, event.id);
+
         return event.id;
     }
 
@@ -404,6 +411,9 @@ export class AgentPublisher {
         injectTraceContext(event);
         await this.agent.sign(event);
         await this.safePublish(event, "followup", parentContext);
+
+        // Register with PendingDelegationsRegistry for q-tag correlation
+        PendingDelegationsRegistry.register(this.agent.pubkey, context.conversationId, event.id);
 
         return event.id;
     }

--- a/src/services/ral/PendingDelegationsRegistry.ts
+++ b/src/services/ral/PendingDelegationsRegistry.ts
@@ -1,0 +1,101 @@
+/**
+ * PendingDelegationsRegistry - Tracks delegation event IDs for q-tag correlation
+ *
+ * This registry stores delegation event IDs at creation time (in AgentPublisher)
+ * and retrieves them at tool completion time (in ToolExecutionTracker).
+ *
+ * This solves the problem of MCP result transformation stripping delegation info:
+ * - Registration happens at the source (AgentPublisher.ask/delegate) before any transformation
+ * - Consumption happens in ToolExecutionTracker.completeExecution
+ * - Works identically for both MCP and non-MCP code paths
+ *
+ * Key: (agentPubkey, conversationId)
+ * Value: Array of delegation event IDs (accumulated, consumed as batch)
+ */
+
+import { logger } from "@/utils/logger";
+
+type RegistryKey = `${string}:${string}`; // agentPubkey:conversationId
+
+class PendingDelegationsRegistryImpl {
+    private delegations = new Map<RegistryKey, string[]>();
+
+    private makeKey(agentPubkey: string, conversationId: string): RegistryKey {
+        return `${agentPubkey}:${conversationId}`;
+    }
+
+    /**
+     * Register a delegation event ID.
+     * Called by AgentPublisher when creating ask/delegate events.
+     *
+     * @param agentPubkey - The agent's pubkey
+     * @param conversationId - The conversation ID (root event ID)
+     * @param delegationEventId - The ID of the created delegation event
+     */
+    register(agentPubkey: string, conversationId: string, delegationEventId: string): void {
+        const key = this.makeKey(agentPubkey, conversationId);
+        const existing = this.delegations.get(key) || [];
+        existing.push(delegationEventId);
+        this.delegations.set(key, existing);
+
+        logger.debug("[PendingDelegationsRegistry] Registered delegation", {
+            agentPubkey: agentPubkey.substring(0, 8),
+            conversationId: conversationId.substring(0, 8),
+            delegationEventId: delegationEventId.substring(0, 8),
+            totalPending: existing.length,
+        });
+    }
+
+    /**
+     * Consume (retrieve and clear) all pending delegation event IDs.
+     * Called by ToolExecutionTracker when completing a delegation tool.
+     *
+     * @param agentPubkey - The agent's pubkey
+     * @param conversationId - The conversation ID (root event ID)
+     * @returns Array of delegation event IDs, empty if none registered
+     */
+    consume(agentPubkey: string, conversationId: string): string[] {
+        const key = this.makeKey(agentPubkey, conversationId);
+        const delegations = this.delegations.get(key) || [];
+        this.delegations.delete(key);
+
+        if (delegations.length > 0) {
+            logger.debug("[PendingDelegationsRegistry] Consumed delegations", {
+                agentPubkey: agentPubkey.substring(0, 8),
+                conversationId: conversationId.substring(0, 8),
+                count: delegations.length,
+                eventIds: delegations.map((id) => id.substring(0, 8)),
+            });
+        }
+
+        return delegations;
+    }
+
+    /**
+     * Peek at pending delegations without consuming them.
+     * Useful for debugging and testing.
+     */
+    peek(agentPubkey: string, conversationId: string): string[] {
+        const key = this.makeKey(agentPubkey, conversationId);
+        return [...(this.delegations.get(key) || [])];
+    }
+
+    /**
+     * Clear all pending delegations.
+     * Useful for testing cleanup.
+     */
+    clear(): void {
+        this.delegations.clear();
+    }
+
+    /**
+     * Get the number of conversations with pending delegations.
+     * Useful for debugging.
+     */
+    get size(): number {
+        return this.delegations.size;
+    }
+}
+
+// Export singleton instance
+export const PendingDelegationsRegistry = new PendingDelegationsRegistryImpl();

--- a/src/services/ral/index.ts
+++ b/src/services/ral/index.ts
@@ -1,2 +1,3 @@
 export { RALRegistry } from "./RALRegistry";
+export { PendingDelegationsRegistry } from "./PendingDelegationsRegistry";
 export * from "./types";

--- a/src/tools/implementations/delegate_crossproject.ts
+++ b/src/tools/implementations/delegate_crossproject.ts
@@ -2,6 +2,7 @@ import type { ToolExecutionContext } from "@/tools/types";
 import { agentStorage } from "@/agents/AgentStorage";
 import { getDaemon } from "@/daemon";
 import { getNDK } from "@/nostr/ndkClient";
+import { PendingDelegationsRegistry } from "@/services/ral";
 import type { StopExecutionSignal } from "@/services/ral/types";
 import type { AISdkTool } from "@/tools/types";
 import { logger } from "@/utils/logger";
@@ -108,6 +109,9 @@ async function executeDelegateCrossProject(
 
     await context.agent.sign(chatEvent);
     await chatEvent.publish();
+
+    // Register with PendingDelegationsRegistry for q-tag correlation
+    PendingDelegationsRegistry.register(context.agent.pubkey, context.conversationId, chatEvent.id);
 
     return {
         __stopExecution: true,


### PR DESCRIPTION
## Summary

- Fixes missing q-tags on tool use events when delegation tools (ask, delegate, etc.) are called through MCP
- MCP result transformation (Claude Code SDK) strips `pendingDelegations` from tool results, causing the tool use event to miss q-tags that should reference the created delegation events
- Solution: Register delegation event IDs at publish time via `PendingDelegationsRegistry`, consume them at tool completion time

## Changes

- Add `PendingDelegationsRegistry` - side-channel registry for event ID correlation
- Register delegation IDs in `AgentPublisher.ask()`, `delegate()`, `delegateFollowup()`
- Register directly in `delegate_crossproject` tool (publishes directly, not via AgentPublisher)
- Consume from registry in `ToolExecutionTracker.completeExecution()`
- Update tests to use registry approach

## Test plan

- [x] Unit tests pass for `ToolExecutionTracker`
- [x] TypeScript compiles without errors
- [x] Integration test verifies q-tags are added to tool use events