### PR TITLE
fix: Apply compression segments before token budget check to prevent redundant LLM calls

### DIFF
--- a/src/services/compression/CompressionService.ts
+++ b/src/services/compression/CompressionService.ts
@@ -111,7 +111,10 @@ export class CompressionService {
     }
 
     const effectiveBudget = tokenBudget ?? compressionConfig.tokenBudget;
-    const currentTokens = estimateTokensFromEntries(entries);
+    // Apply existing compressions before checking token count so we don't
+    // trigger unnecessary LLM calls when existing segments already cover old history.
+    const effectiveEntries = applySegmentsToEntries(entries, existingSegments);
+    const currentTokens = estimateTokensFromEntries(effectiveEntries);
 
     // Check if compression is needed - exit early without creating span
     if (


### PR DESCRIPTION
## Summary

- Fixed a critical performance bug where `CompressionService.performCompression()` checked the token budget against raw, uncompressed entries instead of applying existing compression segments
- This caused redundant LLM compression calls on every `prepare_step`, wasting 263s of LLM time (32% of wall clock) as identified in trace `dea60567c38e`
- Fix adds `applySegmentsToEntries()` call before token estimation so the budget check uses the compressed view, enabling early-exit and eliminating unnecessary LLM overhead

## Changes

- `src/services/compression/CompressionService.ts` — Added `applySegmentsToEntries()` call before token estimation (+3 lines)
- `src/services/compression/__tests__/CompressionService.test.ts` — Added 2 new tests validating early-exit fires when existing segments bring token count under budget (+58 lines)

## Test Results

All 14 tests pass (12 existing + 2 new)

## Context

- **Trace reference**: `dea60567c38e` — showed 90 compression spans with 263s of redundant LLM time (32% of wall clock)
- **Root cause**: Budget check used raw entry token count, ignoring existing compression segments that had already compressed old history below budget
- **Fix**: Once segments cover old history, the compressed view stays under budget and triggers early-exit on subsequent calls
- **Conversation**: `b43d7a991541`

🤖 Generated with [Claude Code](https://claude.com/claude-code)