### PR TITLE
Remove Standalone Mode Support

### DIFF
--- a/src/agents/execution/AgentExecutor.ts
+++ b/src/agents/execution/AgentExecutor.ts
@@ -40,14 +40,13 @@ import type {
     ExecutionContext,
     FullRuntimeContext,
     LLMCompletionRequest,
-    StandaloneAgentContext,
     StreamExecutionResult,
 } from "./types";
 
 const tracer = trace.getTracer("tenex.agent-executor");
 
 export class AgentExecutor {
-    constructor(private standaloneContext?: StandaloneAgentContext) {
+    constructor() {
         // Centralized supervision health check - ensures both total registry size AND
         // post-completion heuristic count are validated (fail-closed semantics)
         assertSupervisionHealth("AgentExecutor");
@@ -86,8 +85,8 @@ export class AgentExecutor {
             agent: agent as ToolRegistryContext["agent"],
             triggeringEvent: originalEvent,
             conversationId: originalEvent.id,
-            projectBasePath: projectPath || this.standaloneContext?.project?.tagValue("d") || "",
-            workingDirectory: projectPath || this.standaloneContext?.project?.tagValue("d") || "",
+            projectBasePath: projectPath || "",
+            workingDirectory: projectPath || "",
             currentBranch: "main",
             agentPublisher: {} as AgentPublisher,
             ralNumber: 0,

--- a/src/agents/execution/types.ts
+++ b/src/agents/execution/types.ts
@@ -41,16 +41,6 @@ export interface ExecutionContext {
     mcpManager?: MCPManager;
 }
 
-/**
- * Minimal context for standalone agent execution
- */
-export interface StandaloneAgentContext {
-    agents: Map<string, AgentInstance>;
-    pubkey: string;
-    signer: NDKPrivateKeySigner;
-    project?: NDKProject;
-    getLessonsForAgent?: (pubkey: string) => NDKAgentLesson[];
-}
 
 /**
  * Result of executeStreaming - discriminated union for clear error handling.

--- a/src/event-handler/project.ts
+++ b/src/event-handler/project.ts
@@ -2,7 +2,7 @@ import type { NDKEvent, NDKProject } from "@nostr-dev-kit/ndk";
 import { NDKMCPTool } from "../events/NDKMCPTool";
 import { getNDK } from "../nostr";
 import { TagExtractor } from "../nostr/TagExtractor";
-import { getProjectContext, isProjectContextInitialized } from "@/services/projects";
+import { getProjectContext } from "@/services/projects";
 import {
     getInstalledMCPEventIds,
     installMCPServerFromEvent,
@@ -37,11 +37,6 @@ export async function handleProjectEvent(event: NDKEvent): Promise<void> {
         "project.agent_count": agentEventIds.length,
         "project.mcp_count": mcpEventIds.length,
     });
-
-    // Only process if project context is initialized (daemon is running)
-    if (!isProjectContextInitialized()) {
-        return;
-    }
 
     try {
         const currentContext = getProjectContext();

--- a/src/nostr/utils.ts
+++ b/src/nostr/utils.ts
@@ -1,4 +1,4 @@
-import { getProjectContext, isProjectContextInitialized } from "@/services/projects";
+import { getProjectContext } from "@/services/projects";
 import type { NDKEvent } from "@nostr-dev-kit/ndk";
 
 /**
@@ -7,11 +7,6 @@ import type { NDKEvent } from "@nostr-dev-kit/ndk";
  * @returns true if the event is from an agent, false if from a user
  */
 export function isEventFromAgent(event: NDKEvent): boolean {
-    if (!isProjectContextInitialized()) {
-        // If no project context, we can't determine if it's from an agent
-        return false;
-    }
-
     const projectCtx = getProjectContext();
 
     // Check if it's from the project manager
@@ -46,11 +41,6 @@ export function isEventFromUser(event: NDKEvent): boolean {
 export function getAgentSlugFromEvent(event: NDKEvent): string | undefined {
     if (!event.pubkey) return undefined;
 
-    if (!isProjectContextInitialized()) {
-        // Project context not initialized
-        return undefined;
-    }
-
     const projectCtx = getProjectContext();
     for (const [slug, agent] of projectCtx.agents) {
         if (agent.pubkey === event.pubkey) {
@@ -67,10 +57,6 @@ export function getAgentSlugFromEvent(event: NDKEvent): string | undefined {
  * @returns Array of agent pubkeys that are targeted by this event
  */
 export function getTargetedAgentPubkeys(event: NDKEvent): string[] {
-    if (!isProjectContextInitialized()) {
-        return [];
-    }
-
     const projectCtx = getProjectContext();
     const targetedPubkeys: string[] = [];
 

--- a/src/services/PubkeyService.ts
+++ b/src/services/PubkeyService.ts
@@ -1,5 +1,5 @@
 import { getNDK } from "@/nostr";
-import { getProjectContext, isProjectContextInitialized } from "@/services/projects";
+import { getProjectContext } from "@/services/projects";
 import { logger } from "@/utils/logger";
 import { PREFIX_LENGTH } from "@/utils/nostr-entity-parser";
 import type { Hexpubkey, NDKEvent } from "@nostr-dev-kit/ndk";
@@ -85,10 +85,6 @@ export class PubkeyService {
      * Uses AgentRegistry's getAgentByPubkey for efficient O(1) lookup.
      */
     private getAgentSlug(pubkey: Hexpubkey): string | undefined {
-        if (!isProjectContextInitialized()) {
-            return undefined;
-        }
-
         const projectCtx = getProjectContext();
 
         // Use direct pubkey lookup from AgentRegistry (O(1) instead of O(n))

--- a/src/services/agents/EscalationService.ts
+++ b/src/services/agents/EscalationService.ts
@@ -31,7 +31,7 @@ import { createAgentInstance } from "@/agents/agent-loader";
 import { pubkeyFromNsec } from "@/nostr";
 import { resolveRecipientToPubkey } from "@/services/agents/AgentResolution";
 import { config as configService } from "@/services/ConfigService";
-import { getProjectContext, isProjectContextInitialized } from "@/services/projects";
+import { getProjectContext } from "@/services/projects";
 import { logger } from "@/utils/logger";
 
 export interface EscalationResolutionResult {
@@ -110,12 +110,6 @@ async function autoAddEscalationAgent(
         logger.warn("[EscalationService] Escalation agent configured but not found in system", {
             escalationAgentSlug,
         });
-        return null;
-    }
-
-    // Verify project context is available
-    if (!isProjectContextInitialized()) {
-        logger.warn("[EscalationService] Cannot auto-add escalation agent: project context not initialized");
         return null;
     }
 

--- a/src/utils/delegation-chain.ts
+++ b/src/utils/delegation-chain.ts
@@ -32,7 +32,7 @@
 import type { NDKEvent } from "@nostr-dev-kit/ndk";
 import { ConversationStore } from "@/conversations/ConversationStore";
 import type { DelegationChainEntry } from "@/conversations/types";
-import { getProjectContext, isProjectContextInitialized } from "@/services/projects";
+import { getProjectContext } from "@/services/projects";
 import { getPubkeyService } from "@/services/PubkeyService";
 import { logger } from "@/utils/logger";
 import { PREFIX_LENGTH } from "@/utils/nostr-entity-parser";
@@ -74,14 +74,7 @@ export function buildDelegationChain(
     const chain: DelegationChainEntry[] = [];
 
     // Get project context for agent resolution
-    let projectContext: ReturnType<typeof getProjectContext> | undefined;
-    try {
-        if (isProjectContextInitialized()) {
-            projectContext = getProjectContext();
-        }
-    } catch {
-        // Project context not available - will use fallback resolution
-    }
+    const projectContext = getProjectContext();
 
     /**
      * Helper to resolve a pubkey to a display name.
@@ -95,11 +88,9 @@ export function buildDelegationChain(
             return { displayName, isUser: true };
         }
 
-        if (projectContext) {
-            const agent = projectContext.getAgentByPubkey(pubkey);
-            if (agent) {
-                return { displayName: agent.slug, isUser: false };
-            }
+        const agent = projectContext.getAgentByPubkey(pubkey);
+        if (agent) {
+            return { displayName: agent.slug, isUser: false };
         }
 
         // Unknown pubkey - use truncated version


### PR DESCRIPTION
## Overview
Removes all legacy code supporting agents running outside of project context. All agents now run exclusively in project context.

## Changes
- Deleted ~205 lines of dead/unused code
- Removed defensive guards checking for project context initialization
- Fixed issues from two rounds of clean-code-nazi review
- Simplified prompt building logic

## Technical Details

### Deleted Dead Code
- `buildStandaloneSystemPromptMessages()` - exported but never called
- `buildStandaloneMainPrompt()` - unused function
- `BuildStandalonePromptOptions` interface - only used by dead functions
- `StandaloneAgentContext` interface - never used in instantiation
- `standaloneContext` parameter from `AgentExecutor` constructor

### Removed Defensive Guards
Files that had `isProjectContextInitialized()` checks removed:
- `src/nostr/utils.ts`
- `src/services/trust-pubkeys/TrustPubkeyService.ts`
- `src/services/agents/EscalationService.ts`
- `src/services/PubkeyService.ts`
- `src/utils/delegation-chain.ts`
- `src/event-handler/project.ts`
- `src/services/status/ProjectStatusService.ts`

### Fixed Issues from Code Review
- **TrustPubkeyService**: Use `projectContextStore.getContext()` (non-throwing) instead of unguarded `getProjectContext()`
- **ProjectStatusService**: Made `projectContext` required, removed dead single-project mode
- **ProjectRuntime**: Wrapped `warmUserProfileCache()` in `projectContextStore.run()` to prevent throws during daemon warmup

## Context
- **Original Conversation**: ec3c9db436d2
- **Clean Code Reviews**: Two rounds completed with all feedback addressed
- **Build Status**: ✅ Passes

## Impact
- All agents now run exclusively in project context
- Simplified architecture with ~205 lines of dead code removed
- Improved consistency across services