### PR TITLE
fix: thread transient skills into prepareStep system prompt compilation

### DIFF
--- a/src/agents/execution/AgentExecutor.ts
+++ b/src/agents/execution/AgentExecutor.ts
@@ -549,6 +549,8 @@ export class AgentExecutor {
             llmService: setup.llmService,
             messageCompiler: setup.messageCompiler,
             nudgeContent: setup.nudgeContent,
+            skillContent: setup.skillContent,
+            skills: setup.skills,
             ephemeralMessages: setup.ephemeralMessages,
             abortSignal: setup.abortSignal,
             metaModelSystemPrompt: setup.metaModelSystemPrompt,

--- a/src/agents/execution/StreamCallbacks.ts
+++ b/src/agents/execution/StreamCallbacks.ts
@@ -11,6 +11,7 @@ import { llmServiceFactory } from "@/llm/LLMServiceFactory";
 import { shortenConversationId } from "@/utils/conversation-id";
 import { config as configService } from "@/services/ConfigService";
 import { RALRegistry } from "@/services/ral";
+import type { SkillData } from "@/services/skill";
 import { logger } from "@/utils/logger";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import type { LanguageModel, ModelMessage } from "ai";
@@ -56,6 +57,10 @@ export interface PrepareStepConfig {
     messageCompiler: MessageCompiler;
     ephemeralMessages: Array<{ role: "user" | "system"; content: string }>;
     nudgeContent: string;
+    /** Concatenated skill content */
+    skillContent: string;
+    /** Individual skill data for system prompt rendering */
+    skills: SkillData[];
     ralNumber: number;
     execContext: RALExecutionContext;
     executionSpan?: ReturnType<typeof trace.getActiveSpan>;
@@ -79,6 +84,8 @@ export function createPrepareStep(
         messageCompiler,
         ephemeralMessages,
         nudgeContent,
+        skillContent,
+        skills,
         ralNumber,
         execContext,
         executionSpan,
@@ -215,6 +222,8 @@ export function createPrepareStep(
                     mcpManager: projectContext.mcpManager,
                     agentLessons: projectContext.agentLessons,
                     nudgeContent,
+                    skillContent,
+                    skills,
                     respondingToPubkey: context.triggeringEvent.pubkey,
                     pendingDelegations,
                     completedDelegations,

--- a/src/agents/execution/StreamExecutionHandler.ts
+++ b/src/agents/execution/StreamExecutionHandler.ts
@@ -22,6 +22,7 @@ import { shortenConversationId } from "@/utils/conversation-id";
 import type { EventContext } from "@/nostr/types";
 import { llmOpsRegistry } from "@/services/LLMOperationsRegistry";
 import { RALRegistry } from "@/services/ral";
+import type { SkillData } from "@/services/skill";
 import { clearLLMSpanId } from "@/telemetry/LLMSpanRegistry";
 import type { AISdkTool } from "@/tools/types";
 import { createEventContext } from "@/services/event-context";
@@ -51,6 +52,10 @@ export interface StreamExecutionConfig {
     llmService: LLMService;
     messageCompiler: MessageCompiler;
     nudgeContent: string;
+    /** Concatenated skill content */
+    skillContent: string;
+    /** Individual skill data for system prompt rendering */
+    skills: SkillData[];
     ephemeralMessages: Array<{ role: "user" | "system"; content: string }>;
     abortSignal: AbortSignal;
     metaModelSystemPrompt?: string;
@@ -149,6 +154,8 @@ export class StreamExecutionHandler {
                 messageCompiler: this.config.messageCompiler,
                 ephemeralMessages: this.config.ephemeralMessages,
                 nudgeContent: this.config.nudgeContent,
+                skillContent: this.config.skillContent,
+                skills: this.config.skills,
                 ralNumber,
                 execContext: this.execContext,
                 executionSpan: this.executionSpan,


### PR DESCRIPTION
## Summary

- Transient skills (kind:4202 events tagged via `skill` tag on incoming messages) were fetched correctly but never appeared in the LLM's system prompt
- Root cause: `prepareStep` (called for every step including step 0) recompiles the full system prompt via `MessageCompiler.compile()` but did NOT pass `skillContent` or `skills` — so the skill was dropped before the first LLM call
- Fix: add `skillContent?` and `skills?` to `PrepareStepConfig` and `StreamExecutionConfig`, thread them from `StreamSetupResult` through `StreamExecutionHandler` into `createPrepareStep`, and include them in the `compile()` call — same pattern already used for `nudgeContent`

## Rationale

Investigation via Jaeger traces (conversation `6f9887f39ee4`) confirmed:
1. `tenex.skill.fetch_skills` span showed `skill.fetched_count=1`, `skill.content_length=216` — skill was fetched correctly
2. The `llm.system_prompt` log event (recorded at `getLanguageModel()` call time) showed the skill WAS in the originally compiled messages
3. But `ai.prompt.messages` in the actual `doStream` span showed the skill ABSENT (7823 chars vs 8259 chars with skill)
4. A `tenex.agent.prepare_step` span with `step.number=0` confirmed `prepareStep` ran before the first LLM call and recompiled to just 2 messages (system + user) — without skills

The skill fragment has priority 12 in the prompt builder, so it should appear early in the system prompt. The `MessageCompilerContext` interface already had `skillContent?` and `skills?` fields — the bug was purely that `createPrepareStep` never wired them through.

## Test plan
- [ ] Send a message to an agent with a `skill` tag referencing a valid kind:4202 skill event
- [ ] Verify the agent acknowledges the skill in its response
- [ ] Check Jaeger: `tenex.agent.prepare_step` span should produce a system prompt containing `<transient-skill>` block
- [ ] Verify `ai.prompt.messages` system prompt length matches `llm.system_prompt` log length (no more 436-char discrepancy)

Conv-id: 6f9887f39ee4