### PR TITLE
feat: add conversation short ID to agent system prompt

### DIFF
--- a/src/prompts/fragments/01-agent-identity.ts
+++ b/src/prompts/fragments/01-agent-identity.ts
@@ -1,4 +1,5 @@
 import type { AgentInstance } from "@/agents/types";
+import { shortenConversationId } from "@/utils/conversation-id";
 import { fragmentRegistry } from "../core/FragmentRegistry";
 import type { PromptFragment } from "../core/types";
 
@@ -14,12 +15,17 @@ interface AgentIdentityArgs {
      * This is displayed as "Absolute Path" in the system prompt.
      */
     workingDirectory?: string;
+    /**
+     * Current conversation ID (full hex).
+     * First 12 characters are displayed as short ID in the system prompt.
+     */
+    conversationId?: string;
 }
 
 export const agentIdentityFragment: PromptFragment<AgentIdentityArgs> = {
     id: "agent-identity",
     priority: 1,
-    template: ({ agent, projectTitle, projectOwnerPubkey, workingDirectory }) => {
+    template: ({ agent, projectTitle, projectOwnerPubkey, workingDirectory, conversationId }) => {
         const parts: string[] = [];
 
         // Identity
@@ -49,6 +55,10 @@ export const agentIdentityFragment: PromptFragment<AgentIdentityArgs> = {
             contextLines.push(`- Absolute Path: ${workingDirectory}`);
         }
         contextLines.push(`- User (Owner) pubkey: "${projectOwnerPubkey}"`);
+        if (conversationId) {
+            const shortId = shortenConversationId(conversationId);
+            contextLines.push(`- Current Conversation (short): ${shortId}`);
+        }
         parts.push(contextLines.join("\n"));
 
         return parts.join("\n");

--- a/src/prompts/utils/systemPromptBuilder.ts
+++ b/src/prompts/utils/systemPromptBuilder.ts
@@ -656,6 +656,7 @@ async function buildMainSystemPrompt(options: BuildSystemPromptOptions): Promise
         projectTitle: project.tagValue("title") || "Unknown Project",
         projectOwnerPubkey: project.pubkey,
         workingDirectory,
+        conversationId: conversation.getId(),
     });
 
     // Add agent home directory context


### PR DESCRIPTION
## Summary
Add the current conversation short ID (12-character hex prefix) to the agent system prompt in the Project Context section.

## Motivation
When agents are asked "do you know the current conversation ID?", they previously had no access to this information in their context. This enhancement provides that visibility.

## Changes
- **src/prompts/fragments/01-agent-identity.ts**: Add conversation ID field to Project Context section
- **src/prompts/utils/systemPromptBuilder.ts**: Extract shortId from full conversation ID and pass to fragments

## Benefits
Agents can now:
- Reference their current work with proper context
- Avoid confusion when operating across multiple conversations
- Improve traceability across the system

## Verification
✅ Tested by tenex-tester in conversation f15f2190e9e0
✅ Confirmed conversation short ID appears in agent system prompts
✅ Agents can successfully reference their conversation ID

## Related Conversations
- Enhancement Request: d468319975b6
- Implementation: 719e1e1ef77d
- Verification: f15f2190e9e0
- Merge: c4f5c5ab1d2c (current)
