### PR TITLE
fix(event-handler): clear projectOverrides on global 24020 config update

### DIFF
--- a/src/event-handler/index.ts
+++ b/src/event-handler/index.ts
@@ -441,7 +441,10 @@ export class EventHandler {
                 }
                 // If no tool tags, leave defaultUpdates.tools unset → no change
 
-                const defaultUpdated = await agentStorage.updateDefaultConfig(agentPubkey, defaultUpdates);
+                // Global config update clears all project overrides
+                // This makes semantic sense: a global config update without project specifier
+                // resets the agent to have no project-specific overrides
+                const defaultUpdated = await agentStorage.updateDefaultConfig(agentPubkey, defaultUpdates, { clearProjectOverrides: true });
 
                 if (defaultUpdated) {
                     await agentRegistry.reloadAgent(agentPubkey);


### PR DESCRIPTION
## Summary

Bug fix for kind 24020 (TenexAgentConfigUpdate) events: when no a-tag is present (global config update), projectOverrides are now cleared.

## Problem

When a kind 24020 event was received without an a-tag (global config update), the system:
- Updated the agent default configuration (correct)
- Preserved all existing projectOverrides (bug)

This meant agents could carry stale project-specific configuration even after a global reset.

## Fix

A global config update with no a-tag semantically means: "reset this agent to default config with no project-specific overrides." The fix ensures projectOverrides are cleared when this path is taken.

## Changes

- src/agents/AgentStorage.ts: Added UpdateDefaultConfigOptions interface; updated updateDefaultConfig() with clearProjectOverrides option
- src/event-handler/index.ts: Pass { clearProjectOverrides: true } when no a-tag present in the GLOBAL config update path
- src/agents/__tests__/AgentStorage.test.ts: Added 3 tests for the new behavior
- src/event-handler/__tests__/project-scoped-config.test.ts: Updated mock and assertions

## Conversations

- Bug report & execution: 3ff70d06389f
- Merge: ac098cd279e7
