### PR TITLE
fix(lancedb): batch embedding writes + periodic compaction to eliminate fragmentation

### DIFF
--- a/src/services/rag/LanceDBMaintenanceService.ts
+++ b/src/services/rag/LanceDBMaintenanceService.ts
@@ -1,0 +1,211 @@
+/**
+ * LanceDBMaintenanceService - Periodic compaction and cleanup
+ *
+ * Runs optimize() on all LanceDB tables to:
+ * - Compact small fragment files into larger ones
+ * - Prune old version manifests
+ *
+ * This prevents fragmentation accumulation from frequent writes.
+ * Uses a self-scheduling setTimeout pattern (like ConversationIndexingJob)
+ * to prevent overlapping runs.
+ */
+
+import { logger } from "@/utils/logger";
+import { RAGDatabaseService } from "./RAGDatabaseService";
+
+/** Default interval: 2 hours (in milliseconds) */
+const DEFAULT_INTERVAL_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Cleanup versions older than this duration.
+ * We keep 1 day of history for safety; the current version is never removed.
+ */
+const DEFAULT_CLEANUP_OLDER_THAN_DAYS = 1;
+
+/**
+ * Periodic LanceDB maintenance service
+ */
+export class LanceDBMaintenanceService {
+    private static instance: LanceDBMaintenanceService | null = null;
+    private timer: NodeJS.Timeout | null = null;
+    private isRunning = false;
+    private isMaintenanceRunning = false;
+    private intervalMs: number;
+
+    private constructor(intervalMs: number = DEFAULT_INTERVAL_MS) {
+        this.intervalMs = intervalMs;
+    }
+
+    /**
+     * Get singleton instance
+     */
+    public static getInstance(intervalMs?: number): LanceDBMaintenanceService {
+        if (!LanceDBMaintenanceService.instance) {
+            LanceDBMaintenanceService.instance = new LanceDBMaintenanceService(intervalMs);
+        }
+        return LanceDBMaintenanceService.instance;
+    }
+
+    /**
+     * Start the periodic maintenance job
+     */
+    public start(): void {
+        if (this.isRunning) {
+            logger.warn("LanceDBMaintenanceService is already running");
+            return;
+        }
+
+        this.isRunning = true;
+        logger.info("Starting LanceDBMaintenanceService", {
+            intervalMs: this.intervalMs,
+            intervalHours: this.intervalMs / (60 * 60 * 1000),
+        });
+
+        // Run first maintenance after a short delay (30 seconds)
+        // to let the system finish booting
+        this.scheduleNextRun(30_000);
+    }
+
+    /**
+     * Schedule the next maintenance run (self-scheduling to prevent overlaps)
+     */
+    private scheduleNextRun(delayMs: number): void {
+        if (!this.isRunning) return;
+
+        this.timer = setTimeout(async () => {
+            try {
+                await this.runMaintenance();
+            } catch (error) {
+                logger.error("LanceDB maintenance failed", { error });
+            } finally {
+                // Schedule next run only after this one completes
+                this.scheduleNextRun(this.intervalMs);
+            }
+        }, delayMs);
+    }
+
+    /**
+     * Stop the periodic maintenance job
+     */
+    public stop(): void {
+        if (!this.isRunning) {
+            return;
+        }
+
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+
+        this.isRunning = false;
+        logger.info("LanceDBMaintenanceService stopped");
+    }
+
+    /**
+     * Run maintenance on all LanceDB tables
+     */
+    private async runMaintenance(): Promise<void> {
+        if (this.isMaintenanceRunning) {
+            logger.warn("Skipping LanceDB maintenance - previous run still in progress");
+            return;
+        }
+
+        this.isMaintenanceRunning = true;
+
+        // Use a temporary DB service to avoid coupling to RAGService singleton
+        // (which requires embedding provider initialization)
+        let dbService: RAGDatabaseService | null = null;
+
+        try {
+            dbService = new RAGDatabaseService();
+            const tableNames = await dbService.listTables();
+
+            if (tableNames.length === 0) {
+                logger.debug("No LanceDB tables to optimize");
+                return;
+            }
+
+            logger.info("Starting LanceDB maintenance", { tableCount: tableNames.length });
+
+            const cleanupOlderThan = new Date();
+            cleanupOlderThan.setDate(cleanupOlderThan.getDate() - DEFAULT_CLEANUP_OLDER_THAN_DAYS);
+
+            let optimizedCount = 0;
+
+            for (const tableName of tableNames) {
+                try {
+                    const table = await dbService.getTable(tableName);
+                    const stats = await table.optimize({
+                        cleanupOlderThan,
+                    });
+
+                    optimizedCount++;
+                    logger.info(`Optimized table '${tableName}'`, {
+                        compaction: stats.compaction,
+                        prune: stats.prune,
+                    });
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    logger.error(`Failed to optimize table '${tableName}'`, {
+                        error: message,
+                    });
+                    // Continue with other tables
+                }
+            }
+
+            logger.info("LanceDB maintenance complete", {
+                tablesOptimized: optimizedCount,
+                totalTables: tableNames.length,
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.error("LanceDB maintenance failed", { error: message });
+        } finally {
+            if (dbService) {
+                try {
+                    await dbService.close();
+                } catch (closeError) {
+                    logger.debug("Failed to close maintenance DB service", { error: closeError });
+                }
+            }
+            this.isMaintenanceRunning = false;
+        }
+    }
+
+    /**
+     * Force an immediate maintenance run (for manual triggering)
+     */
+    public async forceRun(): Promise<void> {
+        await this.runMaintenance();
+    }
+
+    /**
+     * Get current service status
+     */
+    public getStatus(): {
+        isRunning: boolean;
+        isMaintenanceRunning: boolean;
+        intervalMs: number;
+    } {
+        return {
+            isRunning: this.isRunning,
+            isMaintenanceRunning: this.isMaintenanceRunning,
+            intervalMs: this.intervalMs,
+        };
+    }
+
+    /**
+     * Reset singleton instance (for testing)
+     */
+    public static resetInstance(): void {
+        if (LanceDBMaintenanceService.instance) {
+            LanceDBMaintenanceService.instance.stop();
+            LanceDBMaintenanceService.instance = null;
+        }
+    }
+}
+
+// Export lazy getter
+export function getLanceDBMaintenanceService(): LanceDBMaintenanceService {
+    return LanceDBMaintenanceService.getInstance();
+}

--- a/src/services/rag/RAGService.ts
+++ b/src/services/rag/RAGService.ts
@@ -3,7 +3,7 @@ import type { EmbeddingProvider } from "@/services/embedding";
 import { EmbeddingProviderFactory } from "./EmbeddingProviderFactory";
 import { RAGDatabaseService } from "./RAGDatabaseService";
 import { RAGOperations } from "./RAGOperations";
-import type { LanceDBSchema, RAGCollection, RAGDocument, RAGQueryResult } from "./RAGOperations";
+import type { BulkUpsertResult, LanceDBSchema, RAGCollection, RAGDocument, RAGQueryResult } from "./RAGOperations";
 
 /**
  * Lightweight check for RAG collections without full service initialization.
@@ -137,6 +137,16 @@ export class RAGService {
     }
 
     /**
+     * Bulk upsert documents using mergeInsert for efficient batched writes.
+     * Creates one LanceDB version per chunk of BATCH_SIZE instead of 2N
+     * (delete+insert per doc). Failures are isolated per chunk.
+     */
+    public async bulkUpsert(collectionName: string, documents: RAGDocument[]): Promise<BulkUpsertResult> {
+        await this.ensureInitialized();
+        return this.operations.bulkUpsert(collectionName, documents);
+    }
+
+    /**
      * Delete a document by its ID
      */
     public async deleteDocumentById(collectionName: string, documentId: string): Promise<void> {
@@ -224,7 +234,7 @@ export class RAGService {
 }
 
 // Export the main types for convenience
-export type { RAGDocument, RAGCollection, RAGQueryResult } from "./RAGOperations";
+export type { BulkUpsertResult, RAGDocument, RAGCollection, RAGQueryResult } from "./RAGOperations";
 export { RAGValidationError, RAGOperationError } from "./RAGOperations";
 export { RAGDatabaseError } from "./RAGDatabaseService";
 // hasRagCollections is exported at module level (above class)


### PR DESCRIPTION
## Problem

The `conversation_embeddings` LanceDB collection had catastrophic fragmentation:
- **27,786 version manifests** (19 GB metadata) for only 209 MB of actual vector data
- Root cause: every conversation embedding write did `table.delete()` + `table.add([1 doc])`,
  creating **2 version manifests per conversation per indexing cycle**
- Result: **601% CPU and 4.7 GB RAM** consumption

## Solution

### Change 1: Batch embedding writes via `mergeInsert`

| File | Change |
|------|--------|
| `src/services/rag/RAGOperations.ts` | Added `bulkUpsert()` using LanceDB's `mergeInsert("id")` API with per-chunk error isolation |
| `src/services/rag/RAGService.ts` | Exposed `bulkUpsert()` through service facade |
| `src/conversations/search/embeddings/ConversationEmbeddingService.ts` | Added `buildDocument()` returning discriminated union `BuildDocumentResult`; added `getCollectionName()` |
| `src/conversations/search/embeddings/ConversationIndexingJob.ts` | Batches all pending conversations into single `bulkUpsert()` call |

**Key design decisions:**
- `BulkUpsertResult { upsertedCount, failedIndices }` — partial failures don't block successful docs
- `BuildDocumentResult` discriminated union (`ok` / `noContent` / `error`) — prevents infinite retry on zero-message conversations
- Creates **1 version manifest per BATCH_SIZE chunk** instead of **2N manifests for N conversations**

### Change 2: Periodic compaction via `LanceDBMaintenanceService`

| File | Change |
|------|--------|
| `src/services/rag/LanceDBMaintenanceService.ts` | New service: periodic `optimizeTable()` runs to compact accumulated manifests |
| `src/daemon/Daemon.ts` | Wires maintenance service into daemon lifecycle |

## Verification

- ✅ TypeScript compiles clean
- ✅ All 27 tests pass  
- ✅ 3 code review cycles with clean-code-nazi — all issues resolved

## Conversation References

- Main orchestration: `6f5db30a0aa4` (Fix LanceDB Fragmentation)
- Initial implementation: `621dc998e23c` (claude-code)
- Round 1 revisions: `3b7cccec1070` (claude-code)
- Round 2 revisions: `d3f1e9da43f9` (claude-code)
- Code reviews: `ce4a389b0b28`, `5d834c00b3bb`, `a261143051b4` (clean-code-nazi, 3 passes)
- Merge conv: `2e5234b5cd25` (git-agent)