### PR TITLE
fix(intervention): skip intervention when agent has active delegations

### DIFF
--- a/src/daemon/Daemon.ts
+++ b/src/daemon/Daemon.ts
@@ -628,16 +628,7 @@ export class Daemon {
         }
     }
 
-    /**
-     * Create an agent resolver function for InterventionService.
-     * This allows Layer 3 (InterventionService) to resolve agents per-project
-     * without directly depending on Layer 4 (Daemon).
-     *
-     * Returns a function that:
-     * - Returns { status: "resolved", pubkey } when agent is found
-     * - Returns { status: "runtime_unavailable" } when project runtime not active (transient)
-     * - Returns { status: "agent_not_found" } when agent slug doesn't exist (permanent)
-     */
+    /** Create an agent resolver for InterventionService to resolve agents per-project. */
     private createAgentResolver(): (projectId: string, agentSlug: string) => AgentResolutionResult {
         return (projectId: string, agentSlug: string): AgentResolutionResult => {
             // Get active runtimes

--- a/src/daemon/routing/DaemonRouter.ts
+++ b/src/daemon/routing/DaemonRouter.ts
@@ -278,7 +278,7 @@ export class DaemonRouter {
                     );
                 }
 
-                logger.info("Routing event to project via A-tag", {
+                logger.info("Routing event to project via a-tag", {
                     eventId: event.id.slice(0, 8),
                     eventKind: event.kind,
                     projectId: aTagValue,
@@ -289,7 +289,7 @@ export class DaemonRouter {
                     projectId: aTagValue,
                     method: "a_tag",
                     matchedTags: [aTagValue],
-                    reason: `Matched project A-tag: ${aTagValue}`,
+                    reason: `Matched project a-tag: ${aTagValue}`,
                 };
             }
         }

--- a/src/services/intervention/InterventionService.ts
+++ b/src/services/intervention/InterventionService.ts
@@ -371,22 +371,6 @@ export class InterventionService {
     }
 
     /**
-     * Check if the intervention agent can be resolved for a given project.
-     * Used during onAgentCompletion to validate before scheduling the timer.
-     *
-     * Returns:
-     * - "can_resolve": Agent exists and can be resolved
-     * - "runtime_unavailable": Runtime temporarily unavailable (transient - should queue)
-     * - "agent_not_found": Agent slug doesn't exist in project (permanent failure)
-     *
-     * @param projectId - The project ID to check
-     */
-    private checkAgentResolution(projectId: string): AgentResolutionResult["status"] {
-        const result = this.resolveAgentPubkeyForProject(projectId);
-        return result.status;
-    }
-
-    /**
      * Check if the service is enabled and ready.
      */
     public isEnabled(): boolean {
@@ -425,7 +409,6 @@ export class InterventionService {
             return;
         }
 
-        // Check if we can resolve the intervention agent for this project
         // Distinguish between transient (runtime unavailable) and permanent (agent not found) failures
         const resolution = this.resolveAgentPubkeyForProject(projectId);
 

--- a/src/services/intervention/__tests__/InterventionService.test.ts
+++ b/src/services/intervention/__tests__/InterventionService.test.ts
@@ -135,6 +135,9 @@ mock.module("@/services/trust-pubkeys/TrustPubkeyService", () => ({
 // Import after mocks are set up
 import { InterventionService } from "../InterventionService";
 
+/** Fixed timestamp for deterministic tests (avoids Date.now() non-determinism). */
+const FIXED_COMPLETION_TIME = 1_700_000_000_000;
+
 describe("InterventionService", () => {
     let tempDir: string;
     let projectAgents: Map<string, Array<{ slug: string; pubkey: string }>>;
@@ -1652,7 +1655,7 @@ describe("InterventionService", () => {
             // Completion should be queued despite resolver throwing
             service.onAgentCompletion(
                 "test-conv-1",
-                Date.now() + 10000,
+                FIXED_COMPLETION_TIME + 10000,
                 "agent-123",
                 "user-456",
                 "project-789"
@@ -1664,8 +1667,6 @@ describe("InterventionService", () => {
     });
 
     describe("active delegation checking", () => {
-        const FIXED_COMPLETION_TIME = 1700000000000; // Fixed timestamp for deterministic tests
-
         it("should skip intervention when agent has active delegations", async () => {
             // Create a mock delegation checker that returns true (has active delegations)
             const mockDelegationChecker = mock((_agentPubkey: string, _conversationId: string) => true);

--- a/src/services/intervention/index.ts
+++ b/src/services/intervention/index.ts
@@ -1,2 +1,7 @@
 export { InterventionService } from "./InterventionService";
-export type { PendingIntervention, AgentResolutionResult, AgentResolverFn, ActiveDelegationCheckerFn } from "./InterventionService";
+export type {
+    PendingIntervention,
+    AgentResolutionResult,
+    AgentResolverFn,
+    ActiveDelegationCheckerFn,
+} from "./InterventionService";


### PR DESCRIPTION
## Summary

Fixes a bug where intervention-review notifications were being sent prematurely when there are still active delegations in the conversation.

## Problem

When an agent had pending/active delegations outstanding, the intervention service was still evaluating and sending notifications. This caused premature intervention-review events to fire while agents were still actively working on delegated tasks, creating a noisy and incorrect notification loop.

## Solution

Added a check in the `InterventionService` to skip intervention review when the agent currently has active delegations. The service now waits until all delegations have completed before evaluating whether an intervention notification should be sent.

Code review cleanups were then applied on top of the core fix.

## Commits

- `7c9d3f8c` fix(intervention): skip intervention when agent has active delegations
- `4ade9e21` refactor(intervention): apply code review cleanups on top of delegation fix

## Technical Details

- **Source branch**: `fix/notification-loop`
- **Pinned SHA**: `4ade9e21fa9ee9477da253dfd3b7fccb1409d319`
- **Conversation ID**: `ff4c7ee16a8b` (git-agent merge task)
- **Parent conversation**: `62893b81bca8` (architect-orchestrator: Fix Notification Logic)

## Files Changed

- `src/services/intervention/InterventionService.ts` — core fix: active delegation guard
- `src/services/intervention/__tests__/InterventionService.test.ts` — test coverage for new behavior