### PR TITLE
fix: disable TaskOutput built-in command in ClaudeCodeProvider

### DIFF
--- a/src/llm/providers/agent/ClaudeCodeProvider.ts
+++ b/src/llm/providers/agent/ClaudeCodeProvider.ts
@@ -63,7 +63,7 @@ const TOOL_MAPPINGS: Readonly<Record<string, ToolMapping>> = {
 const FS_TOOL_NAMES = ["fs_read", "fs_write", "fs_edit", "fs_glob", "fs_grep"] as const;
 
 /** Built-in tools that TENEX always controls — agents get these only via TENEX's equivalents */
-const ALWAYS_DISABLED_BUILTINS = ["Read", "Write", "Edit", "Glob", "Grep", "LS", "NotebookEdit", "Bash"] as const;
+const ALWAYS_DISABLED_BUILTINS = ["Read", "Write", "Edit", "Glob", "Grep", "LS", "NotebookEdit", "Bash", "TaskOutput"] as const;
 
 /** Pattern to detect MCP tools that provide FS capability */
 const MCP_FS_CAPABILITY_PATTERN = /mcp__.*__(fs_read|fs_write|fs_edit|fs_glob|fs_grep|read_file|write_file|edit_file|list_directory)/;

--- a/src/llm/providers/agent/__tests__/ClaudeCodeProvider.test.ts
+++ b/src/llm/providers/agent/__tests__/ClaudeCodeProvider.test.ts
@@ -76,6 +76,7 @@ describe("ClaudeCodeProvider", () => {
                 expect(disallowed).toContain("LS");
                 expect(disallowed).toContain("NotebookEdit");
                 expect(disallowed).toContain("Bash");
+                expect(disallowed).toContain("TaskOutput");
             });
 
             it("should disable all TENEX-controlled built-ins regardless of agent tools", () => {
@@ -92,6 +93,7 @@ describe("ClaudeCodeProvider", () => {
                 expect(disallowed).toContain("LS");
                 expect(disallowed).toContain("NotebookEdit");
                 expect(disallowed).toContain("Bash");
+                expect(disallowed).toContain("TaskOutput");
             });
         });
 
@@ -152,6 +154,7 @@ describe("ClaudeCodeProvider", () => {
                 expect(disallowed).toContain("WebFetch");
                 expect(disallowed).toContain("WebSearch");
                 expect(disallowed).toContain("Bash");
+                expect(disallowed).toContain("TaskOutput");
                 expect(disallowed).toContain("Task");
                 expect(disallowed).toContain("TodoWrite");
             });
@@ -170,6 +173,7 @@ describe("ClaudeCodeProvider", () => {
                 expect(disallowed).toContain("LS");
                 expect(disallowed).toContain("NotebookEdit");
                 expect(disallowed).toContain("Bash");
+                expect(disallowed).toContain("TaskOutput");
 
                 // delegate is provided, so Task should be disabled
                 expect(disallowed).toContain("Task");
@@ -223,6 +227,7 @@ describe("ClaudeCodeProvider", () => {
             expect(settings.disallowedTools).toContain("LS");
             expect(settings.disallowedTools).toContain("NotebookEdit");
             expect(settings.disallowedTools).toContain("Bash");
+            expect(settings.disallowedTools).toContain("TaskOutput");
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds `TaskOutput` to the `ALWAYS_DISABLED_BUILTINS` array in `ClaudeCodeProvider.ts`, preventing agents from using this built-in command directly.

## Changes

- **`ClaudeCodeProvider.ts`**: Added `"TaskOutput"` to `ALWAYS_DISABLED_BUILTINS` array
- **`ClaudeCodeProvider.test.ts`**: Updated 5 test cases to assert `TaskOutput` is in the disallowed tools list

## Rationale

`TaskOutput` was available to agents as a Claude built-in command but should be controlled by TENEX rather than exposed directly. This follows the established pattern of disabling built-ins that TENEX manages through its own equivalents (Bash, Read, Write, Edit, Glob, Grep, LS, NotebookEdit).

## Conversation Context

- Conversation ID: `ec1dcbf7a5ca` (Remove TaskOutput Command)
- Parent: `19a0161ec1c2` (architect-orchestrator request)