### PR TITLE
feat(agent_read): return compiled instructions and memorized reports

### DIFF
--- a/src/services/prompt-compiler/prompt-compiler-service.ts
+++ b/src/services/prompt-compiler/prompt-compiler-service.ts
@@ -169,7 +169,7 @@ export class PromptCompilerService {
         this.ndk = ndk;
 
         // Cache at ~/.tenex/agents/prompts/{agentPubkey}.json
-        this.cacheDir = path.join(config.getConfigPath(), "agents", "prompts");
+        this.cacheDir = path.dirname(PromptCompilerService.getCachePathForAgent(agentPubkey));
     }
 
     /**
@@ -1076,10 +1076,19 @@ Please rewrite and compile this into unified, cohesive Effective Agent Instructi
     // =====================================================================================
 
     /**
+     * Get the cache file path for a given agent pubkey.
+     * Static variant for external consumers that need to read the cache directly.
+     */
+    static getCachePathForAgent(agentPubkey: string): string {
+        const cacheDir = path.join(config.getConfigPath(), "agents", "prompts");
+        return path.join(cacheDir, `${agentPubkey}.json`);
+    }
+
+    /**
      * Get the cache file path for this agent
      */
     private getCachePath(): string {
-        return path.join(this.cacheDir, `${this.agentPubkey}.json`);
+        return PromptCompilerService.getCachePathForAgent(this.agentPubkey);
     }
 
     /**


### PR DESCRIPTION
## Summary

Enhanced the `agent_read` tool to return **both** the base agent definition and compiled runtime data when available.

## Motivation

Previously, `agent_read` only returned the base `StoredAgent` definition (raw `instructions` field). The compiled/runtime version — which includes auto-injected content, AGENTS.md context, memorized lessons, and memorized reports — was only available during agent execution in `AgentExecutor.buildSystemPrompt()`.

This enhancement makes the compiled state accessible to tools and agents that need to inspect what an agent actually runs with, not just its raw definition. Valuable for debugging, agent introspection, and orchestration scenarios.

## Changes

### `src/tools/implementations/agents_read.ts`
- Added `compiledInstructions: string | null` to response schema
- Added `memorizedReports: MemorizedReport[]` to response schema
- Implemented `readCompiledInstructions()`: reads from `PromptCompilerService` disk cache via new static helper
- Implemented `readMemorizedReports()`: fetches team + agent-specific memorized reports from `ReportService`, deduplicates by slug (team takes precedence), filters deleted entries
- Updated tool description

### `src/services/prompt-compiler/prompt-compiler-service.ts`
- Added **static** `getCachePathForAgent(agentPubkey)` to expose cache path without requiring service instantiation
- Refactored private `getCachePath()` to delegate to the static variant

## Implementation Details

- Compiled instructions: best-effort (returns `null` if no cache exists yet)
- Memorized reports: best-effort (returns `[]` if `ReportService` fails)
- Team reports and agent-specific reports are deduplicated by slug; team takes precedence
- Deleted reports are filtered out

## Conversation References

- Feature request conversation: `006c0467999de924df56bf67e69e98000d65655b2abe62858f1f556948d01e0f`
- Requested by: Pablo Testing Pubkey (`09d48a1a5dbe13404a729634f1d6ba722d40513468dd713c8ea38ca9b7b6f2c7`)