### PR TITLE
fix(prompts): use short 12-char conversation IDs in system prompt fragments

### DIFF
--- a/src/prompts/fragments/08-active-conversations.ts
+++ b/src/prompts/fragments/08-active-conversations.ts
@@ -3,6 +3,7 @@ import { conversationRegistry } from "@/conversations/ConversationRegistry";
 import { formatRelativeTimeShort } from "@/lib/time";
 import { RALRegistry } from "@/services/ral/RALRegistry";
 import { getPubkeyService } from "@/services/PubkeyService";
+import { shortenConversationId } from "@/utils/conversation-id";
 import { logger } from "@/utils/logger";
 import type { PromptFragment } from "../core/types";
 
@@ -201,7 +202,7 @@ export const activeConversationsFragment: PromptFragment<ActiveConversationsArgs
         }
 
         const conversationLines = activeConversations.map((conv, index) => {
-            const title = conv.title || `Conversation ${conv.conversationId.substring(0, 8)}...`;
+            const title = conv.title || `Conversation ${shortenConversationId(conv.conversationId)}...`;
             const duration = formatDuration(conv.startedAt);
             const lastActivity = formatRelativeTimeShort(Math.floor(conv.lastActivityAt / 1000));
 
@@ -218,7 +219,7 @@ export const activeConversationsFragment: PromptFragment<ActiveConversationsArgs
             const summaryLine = conv.summary ? `\n   Summary: ${conv.summary}` : "";
 
             return `${index + 1}. **${title}**
-   - ID: ${conv.conversationId}
+   - ID: ${shortenConversationId(conv.conversationId)}
    - Agent: ${conv.agentName}
    - Status: ${status}
    - Duration: ${duration}

--- a/src/prompts/fragments/09-recent-conversations.ts
+++ b/src/prompts/fragments/09-recent-conversations.ts
@@ -1,6 +1,7 @@
 import type { AgentInstance } from "@/agents/types";
 import { ConversationStore } from "@/conversations/ConversationStore";
 import { formatRelativeTimeShort } from "@/lib/time";
+import { shortenConversationId } from "@/utils/conversation-id";
 import { logger } from "@/utils/logger";
 import type { PromptFragment } from "../core/types";
 
@@ -133,7 +134,7 @@ export const recentConversationsFragment: PromptFragment<RecentConversationsArgs
         }
 
         const conversationLines = recentConversations.map((conv, index) => {
-            const title = conv.title || `Conversation ${conv.id.substring(0, 8)}...`;
+            const title = conv.title || `Conversation ${shortenConversationId(conv.id)}...`;
             const relativeTime = formatRelativeTimeShort(conv.lastActivity);
             // Summary is already sanitized (no newlines), safe to include inline
             const summaryLine = conv.summary ? `\n   Summary: ${conv.summary}` : "";


### PR DESCRIPTION
## Summary

Replace full 64-char hex conversation IDs with short 12-char versions in the active and recent conversations system prompt fragments.

## Changes

- **`src/prompts/fragments/08-active-conversations.ts`**: Import and apply `shortenConversationId()` for both the fallback title and the ID field in the conversation list
- **`src/prompts/fragments/09-recent-conversations.ts`**: Import and apply `shortenConversationId()` for the fallback title

## Rationale

The delegation tool already returned short 12-char IDs, but the system prompt fragments were still emitting full 64-char hex IDs. This created inconsistency — agents would see short IDs from delegation responses but full IDs in their active/recent conversation lists.

The `shortenConversationId()` utility already existed in `src/utils/conversation-id.ts`. This fix applies it consistently across all prompt fragments for uniformity and reduced context window consumption.

## Context

- Conversation: `1581e8e2438e` (1581e8e2438e4ddfa9e75a5de9513194fc5cbaae262bbd540b45efde97716b86)
- Requested by user: "the delegation tool should only return the short version of the conversation id -- same for the active conversations and recent conversations system prompt fragments"
- Surgical fix: 2 files, import + apply existing utility

## Testing

Build passes. Verification step skipped per user request (urgency).