### PR TITLE
fix(subscriptions): migrate NDK subscribe API from EventEmitter to callback-in-options

### DIFF
--- a/src/daemon/AGENTS.md
+++ b/src/daemon/AGENTS.md
@@ -76,13 +76,13 @@ import { SubscriptionManager } from "@/daemon/SubscriptionManager";
 
 const manager = new SubscriptionManager(ndkClient);
 
-// Subscribe to conversation events
+// Subscribe to conversation events (NDK v3 callback-in-options pattern)
 const sub = manager.subscribe({
   kinds: [4199],  // Conversation events
   "#p": [agentPubkey]
+}, {
+  onEvent: handleEvent,
 });
-
-sub.on("event", handleEvent);
 ```
 
 ### RuntimeLifecycle

--- a/src/daemon/SubscriptionManager.ts
+++ b/src/daemon/SubscriptionManager.ts
@@ -170,9 +170,8 @@ export class SubscriptionManager {
         const sub = this.ndk.subscribe([filter], {
             closeOnEose: false,
             groupable: true,
+            onEvent: (event: NDKEvent) => this.handleEvent(event),
         });
-
-        sub.on("event", (event: NDKEvent) => this.handleEvent(event));
 
         this.lessonSubscriptions.set(definitionId, sub);
         logger.debug("Lesson subscription added", {
@@ -262,12 +261,10 @@ export class SubscriptionManager {
         const sub = this.ndk.subscribe(filters, {
             closeOnEose: false,
             groupable: false,
-        });
-
-        sub.on("event", (event: NDKEvent) => this.handleEvent(event));
-
-        sub.on("eose", () => {
-            logger.debug(`Subscription EOSE received [${label}]`);
+            onEvent: (event: NDKEvent) => this.handleEvent(event),
+            onEose: () => {
+                logger.debug(`Subscription EOSE received [${label}]`);
+            },
         });
 
         return sub;

--- a/src/services/AgentDefinitionMonitor.ts
+++ b/src/services/AgentDefinitionMonitor.ts
@@ -331,10 +331,9 @@ export class AgentDefinitionMonitor {
         this.subscription = this.ndk.subscribe(filter, {
             closeOnEose: false,
             groupable: false,
-        });
-
-        this.subscription.on("event", (event: NDKEvent) => {
-            this.handleIncomingEvent(event);
+            onEvent: (event: NDKEvent) => {
+                this.handleIncomingEvent(event);
+            },
         });
     }
 

--- a/src/services/OwnerAgentListService.ts
+++ b/src/services/OwnerAgentListService.ts
@@ -194,12 +194,13 @@ export class OwnerAgentListService {
                 kinds: [NDKKind.ProjectAgentSnapshot as number],
                 authors: this.ownerPubkeys,
             },
-            { closeOnEose: false },
+            {
+                closeOnEose: false,
+                onEvent: (event: NDKEvent) => {
+                    this.handleIncomingEvent(event);
+                },
+            },
         );
-
-        this.subscription.on("event", (event: NDKEvent) => {
-            this.handleIncomingEvent(event);
-        });
 
         logger.debug("[OwnerAgentListService] Started 14199 subscription", {
             ownerCount: this.ownerPubkeys.length,

--- a/src/services/apns/APNsService.ts
+++ b/src/services/apns/APNsService.ts
@@ -113,17 +113,18 @@ export class APNsService {
                 kinds: [NDKKind.TenexConfigUpdate as number],
                 "#p": [backendPubkey],
             },
-            { closeOnEose: false }
+            {
+                closeOnEose: false,
+                onEvent: (event: NDKEvent) => {
+                    this.handleConfigUpdateEvent(event).catch((err) => {
+                        logger.error(`${LOG_PREFIX} Error handling config update event`, {
+                            error: err instanceof Error ? err.message : String(err),
+                            eventId: event.id?.substring(0, 8),
+                        });
+                    });
+                },
+            }
         );
-
-        this.subscription.on("event", (event: NDKEvent) => {
-            this.handleConfigUpdateEvent(event).catch((err) => {
-                logger.error(`${LOG_PREFIX} Error handling config update event`, {
-                    error: err instanceof Error ? err.message : String(err),
-                    eventId: event.id?.substring(0, 8),
-                });
-            });
-        });
 
         this.initialized = true;
 

--- a/src/services/nudge/NudgeWhitelistService.ts
+++ b/src/services/nudge/NudgeWhitelistService.ts
@@ -121,12 +121,13 @@ export class NudgeSkillWhitelistService {
                 kinds: [NDKKind.NudgeSkillWhitelist],
                 authors,
             },
-            { closeOnEose: false }
+            {
+                closeOnEose: false,
+                onEvent: (event: NDKEvent) => {
+                    this.handleWhitelistEvent(event);
+                },
+            }
         );
-
-        this.subscription.on("event", (event: NDKEvent) => {
-            this.handleWhitelistEvent(event);
-        });
 
         logger.debug("[NudgeSkillWhitelistService] Started subscription", {
             pubkeyCount: authors.length,

--- a/src/services/prompt-compiler/prompt-compiler-service.ts
+++ b/src/services/prompt-compiler/prompt-compiler-service.ts
@@ -243,21 +243,19 @@ export class PromptCompilerService {
         this.subscription = this.ndk.subscribe([filter], {
             closeOnEose: false,
             groupable: true,
-        });
-
-        this.subscription.on("event", (event: NDKEvent) => {
-            this.handleCommentEvent(event);
-        });
-
-        this.subscription.on("eose", () => {
-            logger.debug("PromptCompilerService: EOSE received", {
-                agentPubkey: this.agentPubkey.substring(0, 8),
-                commentsCount: this.getTotalCommentsCount(),
-            });
-            this.eoseReceived = true;
-            if (this.eoseResolve) {
-                this.eoseResolve();
-            }
+            onEvent: (event: NDKEvent) => {
+                this.handleCommentEvent(event);
+            },
+            onEose: () => {
+                logger.debug("PromptCompilerService: EOSE received", {
+                    agentPubkey: this.agentPubkey.substring(0, 8),
+                    commentsCount: this.getTotalCommentsCount(),
+                });
+                this.eoseReceived = true;
+                if (this.eoseResolve) {
+                    this.eoseResolve();
+                }
+            },
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes systematic misuse of the NDK v3 subscription API across all 6 subscription-using services in the backend. All services were using the deprecated EventEmitter `.on('event', ...)` pattern instead of the correct callback-in-options pattern.

## Problem

All subscription services were using the wrong NDK v3 API:

```typescript
// ❌ Wrong (deprecated EventEmitter pattern)
const sub = ndk.subscribe(filters);
sub.on('event', (event) => handler(event));
sub.on('eose', () => eoseHandler());
sub.on('close', () => cleanup());
```

## Fix

Migrated to the correct NDK v3 callback-in-options pattern:

```typescript
// ✅ Correct NDK v3 pattern
ndk.subscribe(filters, {
    onEvent: (event) => handler(event),
    onEose: () => eoseHandler(),
    onClose: () => cleanup()
});
```

## Files Changed

- `src/daemon/SubscriptionManager.ts` — `createSub()` and `addLessonSubscription()`
- `src/services/OwnerAgentListService.ts` — `startSubscription()`
- `src/services/apns/APNsService.ts` — `initialize()`
- `src/services/prompt-compiler/prompt-compiler-service.ts` — `subscribe()`
- `src/services/nudge/NudgeWhitelistService.ts` — `startSubscription()`
- `src/services/AgentDefinitionMonitor.ts` — `subscribe()`
- `src/daemon/AGENTS.md` — updated documentation with correct pattern

All handler logic, debouncing, lifecycle management, and error isolation are preserved — only the wiring mechanism changes.

## Context

- Identified by `ndk-core-expert` in conversation `8401dbbed08a`
- Implemented via `execution-coordinator` in conversation `30fb14aece56`
- Build passes after all changes

## Rationale

NDK v3 changed the subscription API from EventEmitter to callback-in-options. Using the old pattern was silently broken — events were not being received correctly. This fix ensures all subscription-based services receive events as intended.