### PR TITLE
fix(prompts): wire whitelisted skills into prompt pipeline and unify nudges/skills section

### DIFF
--- a/src/agents/execution/MessageCompiler.ts
+++ b/src/agents/execution/MessageCompiler.ts
@@ -77,6 +77,8 @@ export interface MessageCompilerContext {
     ephemeralMessages?: EphemeralMessage[];
     /** Available whitelisted nudges for delegation */
     availableNudges?: WhitelistItem[];
+    /** Available whitelisted skills */
+    availableSkills?: WhitelistItem[];
 }
 
 export interface CompiledMessages {

--- a/src/agents/execution/StreamSetup.ts
+++ b/src/agents/execution/StreamSetup.ts
@@ -282,6 +282,7 @@ export async function setupStreamExecution(
         variantSystemPrompt,
         ephemeralMessages,
         availableNudges: NudgeSkillWhitelistService.getInstance().getWhitelistedNudges(),
+        availableSkills: NudgeSkillWhitelistService.getInstance().getWhitelistedSkills(),
     });
 
     trace.getActiveSpan()?.addEvent("executor.messages_built_from_store", {

--- a/src/prompts/fragments/__tests__/available-nudges.test.ts
+++ b/src/prompts/fragments/__tests__/available-nudges.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { WhitelistItem } from "@/services/nudge";
 import { NDKKind } from "@/nostr/kinds";
-import { availableNudgesFragment } from "../13-available-nudges";
+import { availableNudgesAndSkillsFragment } from "../13-available-nudges";
 
 /**
- * Create a mock WhitelistItem for testing
+ * Create a mock WhitelistItem for testing (nudge)
  */
 function createMockNudge(overrides: Partial<WhitelistItem> = {}): WhitelistItem {
     return {
@@ -17,113 +17,222 @@ function createMockNudge(overrides: Partial<WhitelistItem> = {}): WhitelistItem 
     };
 }
 
-describe("availableNudgesFragment", () => {
+/**
+ * Create a mock WhitelistItem for testing (skill)
+ */
+function createMockSkill(overrides: Partial<WhitelistItem> = {}): WhitelistItem {
+    return {
+        eventId: "skill123def456789012345678901234567890123456789012345678901234",
+        kind: NDKKind.AgentSkill,
+        name: "Test Skill",
+        description: "Test skill description",
+        whitelistedBy: ["pubkey1"],
+        ...overrides,
+    };
+}
+
+describe("availableNudgesAndSkillsFragment (combined nudges + skills)", () => {
     describe("empty state", () => {
-        it("should return empty string when availableNudges is undefined", () => {
-            const result = availableNudgesFragment.template({ availableNudges: undefined as unknown as WhitelistItem[] });
+        it("should return empty string when both are undefined", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: undefined,
+                availableSkills: undefined,
+            });
             expect(result).toBe("");
         });
 
-        it("should return empty string when availableNudges is empty array", () => {
-            const result = availableNudgesFragment.template({ availableNudges: [] });
+        it("should return empty string when both are empty arrays", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: [],
+            });
+            expect(result).toBe("");
+        });
+
+        it("should return empty string when nudges is empty and skills is undefined", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: undefined,
+            });
             expect(result).toBe("");
         });
     });
 
-    describe("nudge list rendering", () => {
+    describe("heading", () => {
+        it("should use 'Available Nudges and Skills' heading with nudges only", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [],
+            });
+            expect(result).toContain("## Available Nudges and Skills");
+        });
+
+        it("should use 'Available Nudges and Skills' heading with skills only", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).toContain("## Available Nudges and Skills");
+        });
+
+        it("should use 'Available Nudges and Skills' heading with both", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).toContain("## Available Nudges and Skills");
+        });
+    });
+
+    describe("subsection headers", () => {
+        it("should NOT show subsection headers when only nudges exist", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [],
+            });
+            expect(result).not.toContain("### Nudges");
+            expect(result).not.toContain("### Skills");
+            expect(result).toContain("**Test Nudge**");
+        });
+
+        it("should NOT show subsection headers when only skills exist", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).not.toContain("### Nudges");
+            expect(result).not.toContain("### Skills");
+            expect(result).toContain("**Test Skill**");
+        });
+
+        it("should show BOTH subsection headers when both nudges and skills exist", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).toContain("### Nudges");
+            expect(result).toContain("### Skills");
+        });
+    });
+
+    describe("nudge-only rendering", () => {
         it("should render a single nudge correctly", () => {
-            const nudges: WhitelistItem[] = [createMockNudge()];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
-            expect(result).toContain("## Available Nudges");
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+            });
             expect(result).toContain("**Test Nudge**");
             expect(result).toContain("Test description");
-            expect(result).toContain("(abc123def456)"); // Truncated event ID
+            expect(result).toContain("(abc123def456)");
         });
 
         it("should render multiple nudges", () => {
-            const nudges: WhitelistItem[] = [
+            const nudges = [
                 createMockNudge({ eventId: "event1", name: "First Nudge" }),
                 createMockNudge({ eventId: "event2", name: "Second Nudge" }),
             ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({ availableNudges: nudges });
             expect(result).toContain("**First Nudge**");
             expect(result).toContain("**Second Nudge**");
         });
 
         it("should use truncated event ID when name is missing", () => {
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ name: undefined }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
-            // Should use first 12 chars of event ID as fallback name
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ name: undefined })],
+            });
             expect(result).toContain("**abc123def456**");
         });
 
         it("should show 'No description' when description is missing", () => {
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ description: undefined }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ description: undefined })],
+            });
             expect(result).toContain("No description");
+        });
+    });
+
+    describe("skill-only rendering", () => {
+        it("should render a single skill correctly", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).toContain("**Test Skill**");
+            expect(result).toContain("Test skill description");
+            expect(result).toContain("(skill123def4)");
+        });
+
+        it("should render multiple skills", () => {
+            const skills = [
+                createMockSkill({ eventId: "event1", name: "First Skill" }),
+                createMockSkill({ eventId: "event2", name: "Second Skill" }),
+            ];
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: skills,
+            });
+            expect(result).toContain("**First Skill**");
+            expect(result).toContain("**Second Skill**");
+        });
+    });
+
+    describe("combined rendering", () => {
+        it("should render both nudges and skills with subsection headers", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [createMockSkill()],
+            });
+
+            expect(result).toContain("## Available Nudges and Skills");
+            expect(result).toContain("### Nudges");
+            expect(result).toContain("**Test Nudge**");
+            expect(result).toContain("### Skills");
+            expect(result).toContain("**Test Skill**");
+        });
+
+        it("should place nudges before skills", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+                availableSkills: [createMockSkill()],
+            });
+
+            const nudgesPos = result.indexOf("### Nudges");
+            const skillsPos = result.indexOf("### Skills");
+            expect(nudgesPos).toBeLessThan(skillsPos);
         });
     });
 
     describe("description truncation (presentation layer)", () => {
         it("should truncate descriptions longer than 150 characters", () => {
             const longDescription = "A".repeat(200);
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ description: longDescription }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
-            // Should be truncated to 150 chars
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ description: longDescription })],
+            });
             expect(result).toContain("A".repeat(150));
             expect(result).not.toContain("A".repeat(151));
         });
 
         it("should not truncate descriptions shorter than 150 characters", () => {
             const shortDescription = "B".repeat(100);
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ description: shortDescription }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ description: shortDescription })],
+            });
             expect(result).toContain(shortDescription);
         });
 
         it("should replace newlines with spaces in descriptions", () => {
-            const descriptionWithNewlines = "Line 1\nLine 2\nLine 3";
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ description: descriptionWithNewlines }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
-            // Should have replaced newlines with spaces in the description
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ description: "Line 1\nLine 2\nLine 3" })],
+            });
             expect(result).toContain("Line 1 Line 2 Line 3");
-            // The description should not contain the original newline pattern
             expect(result).not.toContain("Line 1\nLine 2");
         });
     });
 
     describe("escapePromptText (security)", () => {
         it("should escape HTML/XML entities in name", () => {
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ name: 'Nudge with <script> & "quotes"' }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ name: 'Nudge with <script> & "quotes"' })],
+            });
             expect(result).toContain("&lt;script&gt;");
             expect(result).toContain("&amp;");
             expect(result).toContain("&quot;quotes&quot;");
@@ -131,12 +240,9 @@ describe("availableNudgesFragment", () => {
         });
 
         it("should escape HTML/XML entities in description", () => {
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ description: "Use <b>bold</b> & special chars" }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge({ description: "Use <b>bold</b> & special chars" })],
+            });
             expect(result).toContain("&lt;b&gt;bold&lt;/b&gt;");
             expect(result).toContain("&amp;");
             expect(result).not.toContain("<b>");
@@ -145,33 +251,39 @@ describe("availableNudgesFragment", () => {
 
     describe("example usage section", () => {
         it("should include example delegate call", () => {
-            const nudges: WhitelistItem[] = [createMockNudge()];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+            });
             expect(result).toContain("Example usage:");
             expect(result).toContain("delegate({");
             expect(result).toContain("nudges:");
         });
 
-        it("should use first nudge event ID in example", () => {
-            const nudges: WhitelistItem[] = [
-                createMockNudge({ eventId: "firstnudge12345678901234567890123456789012345678901234567890" }),
-            ];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
-            // Example should use truncated ID of first nudge
+        it("should use first nudge event ID in example when nudges exist", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [
+                    createMockNudge({ eventId: "firstnudge12345678901234567890123456789012345678901234567890" }),
+                ],
+            });
             expect(result).toContain("firstnudge12...");
+        });
+
+        it("should use first skill event ID in example when only skills exist", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [],
+                availableSkills: [
+                    createMockSkill({ eventId: "firstskill12345678901234567890123456789012345678901234567890" }),
+                ],
+            });
+            expect(result).toContain("firstskill12...");
         });
     });
 
     describe("header content", () => {
         it("should explain what nudges are", () => {
-            const nudges: WhitelistItem[] = [createMockNudge()];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+            });
             expect(result).toContain("modify tool availability");
             expect(result).toContain("only-tool");
             expect(result).toContain("allow-tool");
@@ -179,48 +291,67 @@ describe("availableNudgesFragment", () => {
         });
 
         it("should explain nudges inject context into system prompt", () => {
-            const nudges: WhitelistItem[] = [createMockNudge()];
-
-            const result = availableNudgesFragment.template({ availableNudges: nudges });
-
+            const result = availableNudgesAndSkillsFragment.template({
+                availableNudges: [createMockNudge()],
+            });
             expect(result).toContain("inject additional context");
             expect(result).toContain("system prompt");
+        });
+
+        it("should explain skills provide transient capabilities", () => {
+            const result = availableNudgesAndSkillsFragment.template({
+                availableSkills: [createMockSkill()],
+            });
+            expect(result).toContain("transient capabilities");
+            expect(result).toContain("without modifying tool availability");
         });
     });
 
     describe("validateArgs", () => {
-        it("should accept empty object (optional field)", () => {
-            expect(availableNudgesFragment.validateArgs({})).toBe(true);
+        it("should accept empty object (optional fields)", () => {
+            expect(availableNudgesAndSkillsFragment.validateArgs({})).toBe(true);
         });
 
         it("should accept undefined availableNudges", () => {
-            expect(availableNudgesFragment.validateArgs({ availableNudges: undefined })).toBe(true);
+            expect(availableNudgesAndSkillsFragment.validateArgs({ availableNudges: undefined })).toBe(true);
         });
 
-        it("should accept valid availableNudges array", () => {
-            expect(availableNudgesFragment.validateArgs({
+        it("should accept undefined availableSkills", () => {
+            expect(availableNudgesAndSkillsFragment.validateArgs({ availableSkills: undefined })).toBe(true);
+        });
+
+        it("should accept valid arrays for both", () => {
+            expect(availableNudgesAndSkillsFragment.validateArgs({
                 availableNudges: [createMockNudge()],
+                availableSkills: [createMockSkill()],
             })).toBe(true);
         });
 
-        it("should accept empty availableNudges array", () => {
-            expect(availableNudgesFragment.validateArgs({
+        it("should accept empty arrays for both", () => {
+            expect(availableNudgesAndSkillsFragment.validateArgs({
                 availableNudges: [],
+                availableSkills: [],
             })).toBe(true);
         });
 
         it("should reject null", () => {
-            expect(availableNudgesFragment.validateArgs(null)).toBe(false);
+            expect(availableNudgesAndSkillsFragment.validateArgs(null)).toBe(false);
         });
 
         it("should reject non-object", () => {
-            expect(availableNudgesFragment.validateArgs("string")).toBe(false);
-            expect(availableNudgesFragment.validateArgs(123)).toBe(false);
+            expect(availableNudgesAndSkillsFragment.validateArgs("string")).toBe(false);
+            expect(availableNudgesAndSkillsFragment.validateArgs(123)).toBe(false);
         });
 
         it("should reject non-array availableNudges", () => {
-            expect(availableNudgesFragment.validateArgs({
+            expect(availableNudgesAndSkillsFragment.validateArgs({
                 availableNudges: "not an array",
+            })).toBe(false);
+        });
+
+        it("should reject non-array availableSkills", () => {
+            expect(availableNudgesAndSkillsFragment.validateArgs({
+                availableSkills: "not an array",
             })).toBe(false);
         });
     });

--- a/src/prompts/fragments/index.ts
+++ b/src/prompts/fragments/index.ts
@@ -27,7 +27,7 @@ import { todoBeforeDelegationFragment } from "./17-todo-before-delegation";
 import "./20-voice-mode";
 import { nudgesFragment } from "./11-nudges";
 import { skillsFragment } from "./12-skills";
-import { availableNudgesFragment } from "./13-available-nudges";
+import { availableNudgesAndSkillsFragment } from "./13-available-nudges";
 import { scheduledTasksFragment } from "./22-scheduled-tasks";
 import { retrievedLessonsFragment } from "./24-retrieved-lessons";
 import { ragInstructionsFragment } from "./25-rag-instructions";
@@ -73,7 +73,7 @@ export function registerAllFragments(): void {
     // voice-mode and referenced-article are registered via side effects
     fragmentRegistry.register(nudgesFragment);
     fragmentRegistry.register(skillsFragment);
-    fragmentRegistry.register(availableNudgesFragment);
+    fragmentRegistry.register(availableNudgesAndSkillsFragment);
 
     // Scheduled tasks context
     fragmentRegistry.register(scheduledTasksFragment);

--- a/src/prompts/utils/systemPromptBuilder.ts
+++ b/src/prompts/utils/systemPromptBuilder.ts
@@ -112,6 +112,8 @@ export interface BuildSystemPromptOptions {
     skills?: SkillData[];
     /** Available whitelisted nudges for delegation */
     availableNudges?: WhitelistItem[];
+    /** Available whitelisted skills */
+    availableSkills?: WhitelistItem[];
 }
 
 
@@ -357,12 +359,14 @@ function addAgentFragments(
     agent: AgentInstance,
     availableAgents: AgentInstance[],
     projectManagerPubkey?: string,
-    availableNudges?: WhitelistItem[]
+    availableNudges?: WhitelistItem[],
+    availableSkills?: WhitelistItem[]
 ): void {
-    // Add available nudges for delegation (priority 13, before available-agents)
-    if (availableNudges && availableNudges.length > 0) {
-        builder.add("available-nudges", {
+    // Add available nudges and skills for delegation (priority 13, before available-agents)
+    if ((availableNudges && availableNudges.length > 0) || (availableSkills && availableSkills.length > 0)) {
+        builder.add("available-nudges-and-skills", {
             availableNudges,
+            availableSkills,
         });
     }
 
@@ -768,7 +772,8 @@ async function buildMainSystemPrompt(options: BuildSystemPromptOptions): Promise
         agentForFragments,
         availableAgents,
         options.projectManagerPubkey,
-        options.availableNudges
+        options.availableNudges,
+        options.availableSkills
     );
 
     // Build and return the complete prompt with all fragments


### PR DESCRIPTION
## Summary

Fixes a dead-code gap where whitelisted skills (kind:4202 events referenced in a kind:14202 whitelist event) were fetched and cached by `NudgeSkillWhitelistService` but **never injected into agent system prompts**. Also updates the section heading from \"Available Nudges\" to **\"Available Nudges and Skills\"** so agents searching for either term find the section.

## Root Cause

`NudgeSkillWhitelistService.getWhitelistedSkills()` was never called in the prompt-building path. Only `getWhitelistedNudges()` was wired up. This meant any skill referenced in a kind:14202 whitelist was silently ignored at prompt-build time.

Additionally, the heading `## Available Nudges` caused agents asked about \"skills\" to answer that they had none, even when nudges were present.

## Changes

| File | Change |
|------|--------|
| `StreamSetup.ts` | Pass `getWhitelistedSkills()` into message compiler context |
| `MessageCompiler.ts` | Add `availableSkills?: WhitelistItem[]` to context interface |
| `systemPromptBuilder.ts` | Thread `availableSkills` through options and `addAgentFragments()` |
| `13-available-nudges.ts` | Rename to `availableNudgesAndSkillsFragment`, render combined section with subsections when both present |
| `fragments/index.ts` | Update registration to use renamed export |
| `__tests__/available-nudges.test.ts` | 37 tests covering all combinations |

## Testing

- ✅ 1,983 tests passing, 0 regressions
- ✅ 30 new skills pipeline tests
- ✅ 37 new nudges/skills fragment rendering tests
- ✅ TypeScript clean

## Related Conversations

- Investigation: ba816bd6f971 (trace-detective forensic analysis)
- Implementation: f7c21fe664e0

## PR Notes

This is a pure bug-fix with no behavioral changes to the nudges path — only addition of the skills path and heading update.