### PR TITLE
docs: update for Rust workspace; remove stale TypeScript references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,52 +31,46 @@ The goal is **always** the right long-term, sustainable, idiomatic, coherent fix
 - Don't wrap libraries unnecessarily
 - Three similar lines > premature abstraction
 
-### NDK USAGE
-- Import NDK types directly from `@nostr-dev-kit/ndk` for typing
-- Use `src/nostr` wrappers (`AgentPublisher`, `AgentEventEncoder/Decoder`, `ndkClient`) for publishing and decoding
-- Avoid ad-hoc NDK access outside `nostr/` unless tests need mocks
+### NOSTR USAGE
+- Use the `nostr-sdk` crate for Nostr primitives (events, keys, filters).
+- TENEX event kind/tag construction and decoding lives in `tenex-protocol` (intent vocabulary + Nostr channel encoding). Build and parse TENEX events there — never ad-hoc at call sites.
+- Signing is always behind the `Signer` trait (`tenex-project`); never reach for raw keys.
+- The agent runner (`tenex-agent`) does not open relay connections — subscription and orchestration live outside it.
 
 ---
 
 ## Architecture
 
-### Layer Hierarchy (Dependencies Flow DOWN Only)
-```
-Layer 4: commands/ daemon/ event-handler/
-    ↓
-Layer 3: services/ agents/ conversations/ tools/
-    ↓
-Layer 2: llm/ nostr/ prompts/ events/
-    ↓
-Layer 1: utils/
-    ↓
-Layer 0: lib/  ← ZERO TENEX imports
-```
+TENEX is a Rust workspace. The host CLI/supervisor is `tenex/`; every other
+concern is a crate under `crates/`. See `MODULE_INVENTORY.md` for the full map
+and `crates/AGENTS.md` for the authoritative rules.
 
-**Violations are blocking errors. No exceptions.**
+### One crate, one thing
+Each crate owns a single concern — a storage layer, a projection, a daemon, or
+a one-shot binary. New behavior extends the crate that already owns the concern;
+it does not accrete into an unrelated one.
 
-### Layer Rules
+### Three roles, kept separate
+- **Subscribe** — owns the relay connection.
+- **Orchestrate** — owns dispatch, RAL state, the delegation tree.
+- **Execute** — the LLM loop and tools (`tenex-agent`).
 
-| Layer | Can Import | Cannot Import |
-|-------|------------|---------------|
-| `lib/` | Node built-ins, npm only | ANY `@/` imports |
-| `utils/` | `lib/` | `services/`, `agents/`, `commands/` |
-| `services/` | `utils/`, `lib/`, `llm/`, `nostr/` | `commands/`, `daemon/`, `event-handler/` |
-| `commands/` | Everything below | N/A |
+The runner never opens relays; the orchestrator never calls LLMs; the subscriber
+never tracks delegations. Mixing these is the biggest design failure mode here.
 
-### Services Organization
-```
-services/
-├── ral/           ← Delegation/RAL state
-│   ├── RALRegistry.ts
-│   └── types.ts
-├── rag/
-├── mcp/
-├── ConfigService.ts  ← Small services at root
-└── ...
-```
+### Library vs daemon
+Take a process boundary only when you get concurrency/security isolation,
+language choice, independent restart, or hot-swap. Otherwise it is a library. A
+daemon's public surface is a Unix socket speaking NDJSON; a library's is a typed
+Rust API over its substrate (a versioned SQLite schema or a JSON file layout).
+Pick one; never both.
 
-**Rule:** Create subdirectory when 3+ related files exist.
+### Storage is the contract
+SQLite migrations are forward-only and belong only to the crate that owns the
+database; JSON file-layout changes belong only to the crate that owns that
+directory. State lives on disk — every process must survive restart from it.
+
+**Rule:** Project IDs accept either the NIP-33 coordinate (`31933:<pubkey>:<dTag>`) or the bare dTag — normalize once at the owning crate's boundary.
 
 ---
 
@@ -84,35 +78,40 @@ services/
 
 | Type | Convention | Example |
 |------|------------|---------|
-| Services | `*Service` suffix | `ProjectStatusService` |
-| Files (services) | PascalCase | `ProjectStatusService.ts` |
-| Files (utils) | kebab-case | `error-formatter.ts` |
-| Types | `types.ts` or inline | `types.ts` |
-| Tests | `*.test.ts` in `__tests__/` | `__tests__/Foo.test.ts` |
+| Crates | `tenex-<area>`, kebab-case | `tenex-conversations` |
+| Modules / files | snake_case `.rs` | `store.rs`, `schema.rs` |
+| Types | CamelCase | `ConversationStore` |
+| Functions / fields | snake_case | `list_candidates` |
+| Tests | `#[cfg(test)]` module or `tests/*.rs` | `tests/discover_and_read.rs` |
+
+Each crate carries an `AGENTS.md` with its local invariants. Read it before
+changing that crate.
 
 ---
 
-## Import Patterns
+## Dependency Patterns
 
-```typescript
-// CORRECT: Direct imports with @/ alias
-import { RALRegistry } from "@/services/ral";
-import { formatAnyError } from "@/lib/error-formatter";
-import type { NDKEvent } from "@nostr-dev-kit/ndk";
+```rust
+// CORRECT: depend on the crate that owns the concern; import what you need
+use tenex_conversations::ConversationStore;
+use tenex_project::Signer;
 
-// WRONG: Barrel imports
-import { RALRegistry } from "@/services";
-
-// WRONG: Relative cross-module imports
-import { config } from "../../../services/ConfigService";
+// WRONG: reaching across roles — opening a relay from inside the agent runner,
+//        or calling an LLM from the orchestrator
+// WRONG: re-normalizing a project id at every call site instead of once at the
+//        owning crate's boundary
 ```
+
+Crate dependencies are declared in each crate's `Cargo.toml` and the workspace
+`Cargo.toml`. Keep the graph acyclic and minimal. The tree is Rust-only — no
+`bun`/TypeScript imports.
 
 ---
 
 ## Before Writing Code
 
 ### MANDATORY - Answer These Questions First:
-1. **Where does this code belong?** (Check layer hierarchy)
+1. **Which crate owns this concern?** (Extend it; don't add a new crate unless it is a new role in the fleet)
 2. **Does similar code already exist?** (Search before creating)
 3. **What's the minimal change needed?** (No scope creep)
 4. **Am I about to write a TODO?** (Stop. Fix it now or don't do it)
@@ -128,74 +127,72 @@ import { config } from "../../../services/ConfigService";
 
 ## Anti-Patterns to Reject
 
-### Layer Violations
-```typescript
-// REJECT: utils importing services
-// utils/something.ts
-import { config } from "@/services/ConfigService";  // ❌
+### Role / Crate Violations
+```rust
+// REJECT: the agent runner opening a relay connection  ❌
+// REJECT: the orchestrator calling an LLM              ❌
 
-// FIX: Move to services/ or pass config as parameter
+// FIX: keep Subscribe / Orchestrate / Execute separate. Relay access lives
+//      outside tenex-agent; LLM calls live inside it.
+```
+
+### Sentinel Values That Mask Failure
+```rust
+// REJECT: silently turning an error into "not found"
+let view = resolve(pubkey).unwrap_or(None);  // ❌ (on Result<Option<T>>)
+let name = display_name.unwrap_or_else(|| "unknown".into());  // ❌
+
+// FIX: represent absence with Option; propagate or log-and-bail on failure
 ```
 
 ### Backwards Compatibility
-```typescript
-// REJECT: Keeping old interface
-export { OldName as NewName };  // ❌
-export const legacyMethod = newMethod;  // ❌
+```rust
+// REJECT: keeping the old name alive
+pub use new_module::NewName as OldName;  // ❌
 
-// FIX: Just rename it. Update all call sites.
+// FIX: just rename it and update all call sites.
 ```
 
 ### Unused Code
-```typescript
-// REJECT: Underscore prefix for unused
-const _oldValue = compute();  // ❌
+```rust
+// REJECT: underscore prefix for unused
+let _old_value = compute();  // ❌
 
-// FIX: Delete it entirely
+// FIX: delete it entirely
 ```
 
-### God Classes
-```typescript
-// REJECT: Class doing everything
-class ConversationManager {
-  fetch() { }
-  persist() { }
-  format() { }
-  summarize() { }
-  // ... 50 more methods
+### God Modules
+```rust
+// REJECT: one type doing everything
+impl ConversationManager {
+    fn fetch(&self) {}
+    fn persist(&self) {}
+    fn format(&self) {}
+    fn summarize(&self) {}
+    // ... 50 more methods
 }
 
-// FIX: Split into focused services
+// FIX: split by concern across crates/modules
+//      (storage vs projection vs summarizer)
 ```
 
 ---
 
 ## Tool Implementations
 
-Tools in `src/tools/implementations/` should:
-- Be single-purpose (one file = one tool)
-- Delegate business logic to services
+Agent tools live in `crates/tenex-agent/src/tools/` (one file per tool). They should:
+- Be single-purpose
+- Delegate business logic to the crate that owns it (`tenex-rag`, `tenex-mcp`, `tenex-conversations`, …)
 - Never hold state
-- Follow naming: `<domain>_<action>.ts`
+- Follow naming: `<domain>_<action>.rs`
 
-```typescript
-// CORRECT: Tool delegates to service
-import { RAGService } from "@/services/rag";
+```rust
+// CORRECT: the tool delegates to the owning crate
+use tenex_rag::RagStore;
+// ...the tool resolves the store, calls it, and shapes the result.
+// It holds no schema, no SQL, and no vector-store logic itself.
 
-export const rag_search = tool({
-  execute: async ({ query }) => {
-    const ragService = new RAGService();
-    return await ragService.query(query);
-  }
-});
-
-// WRONG: Tool implements business logic directly
-export const rag_search = tool({
-  execute: async ({ query }) => {
-    const db = await connectVectorStore();
-    // ... 100 lines of implementation
-  }
-});
+// WRONG: the tool opens the vector store and implements query logic inline
 ```
 
 ---
@@ -213,8 +210,8 @@ This project runs multiple agents concurrently. Follow these rules to avoid inte
 ## References
 
 - **Full architecture guide:** `docs/ARCHITECTURE.md`
+- **Crate philosophy and rules:** `crates/AGENTS.md`
 - **Module inventory:** `MODULE_INVENTORY.md`
-- **Testing status:** `docs/TESTING_STATUS.md`
 
 ---
 
@@ -224,6 +221,6 @@ This project runs multiple agents concurrently. Follow these rules to avoid inte
 2. **Right fix, not fast fix** - Sustainable, idiomatic, coherent — never expedient
 3. **No backwards compatibility** - Clean breaks only
 4. **No over-engineering** - Minimal changes for the task
-5. **Respect layer boundaries** - Dependencies flow down
-6. **Use `nostr/` wrappers** - Keep NDK publishing/decoding inside `src/nostr`
+5. **Respect crate boundaries** - One crate, one concern; keep the three roles separate
+6. **Build Nostr events in `tenex-protocol`** - Use `nostr-sdk` primitives; sign behind the `Signer` trait
 7. **Delete unused code** - Don't comment or underscore it

--- a/MODULE_INVENTORY.md
+++ b/MODULE_INVENTORY.md
@@ -13,7 +13,7 @@ before adding code, moving behavior, or introducing a new dependency.
 | `crates/tenex-agent-registry/` | `tenex-agent-registry` | JSON-backed global installed-agent registry under `<base_dir>/agents`. Owns agent document normalization, mutation, keys, and index maintenance. |
 | `crates/tenex-context/` | `tenex-context` | Conversation-history projection for LLM prompts. Owns message shaping, token estimates, cache-breakpoint hints, and context-management turn recording. |
 | `crates/tenex-conversations/` | `tenex-conversations` | SQLite conversation store for project-local messages, tool messages, prompt history, context state, completions, project discovery, and migration from older disk formats. |
-| `crates/tenex-embedder/` | `tenex-embedder` | Host daemon + backfill subcommand that embeds conversation transcripts and summaries into per-project RAG stores. Polls `conversation.db`, message-aligned chunking with delegation-marker synthesis, writes to `embeddings.db`. |
+| `crates/tenex-embedder/` | `tenex-embedder` | Host daemon + backfill subcommand that embeds conversation transcripts into the global RAG store. Reads kind:1 events from the relays for the host's owned projects (the local `conversation.db` is not read), message-aligned chunking, writes to `embeddings.db`. |
 | `crates/tenex-identity/` | `tenex-identity` | Host identity cache and daemon for resolving Nostr kind:0 profile data over the configured relays. |
 | `crates/tenex-intervention/` | `tenex-intervention` | Intervention daemon and detector logic for identifying conversations that need owner review or follow-up. |
 | `crates/tenex-llm-config/` | `tenex-llm-config` | Filesystem-backed LLM/provider configuration resolver. Owns standard and meta model resolution, inline model references, provider credentials, and API-key health tracking. |
@@ -133,10 +133,10 @@ before adding code, moving behavior, or introducing a new dependency.
 | `lockfile.rs` | `flock`-based singleton lock at `~/.tenex/embedder.pid`. |
 | `pacing.rs` | Token-bucket-style rate limiter with exponential backoff on 429/5xx. |
 | `paths.rs` | Embedder file paths (`state.db`, `pid`, `embeddings.db`). |
-| `processor.rs` | Per-conversation orchestration: chunk diff, marker synthesis, summary embedding, state cursors. |
-| `progress.rs` | `ProgressReporter` trait + `LogReporter` (daemon) and `IndicatifReporter` (backfill). |
-| `scheduler.rs` | Daemon polling loop. Discovers projects per scan, processes per project. |
-| `source.rs` | Read side over `conversation.db`: headers, messages, child→parent delegation map and fingerprints. |
+| `processor.rs` | Per-conversation orchestration: chunk diff against stored chunks, embedding, state cursors. |
+| `scheduler.rs` | Daemon polling loop (30s). Walks bounded windows of relay history per scan. |
+| `scope.rs` | Derives the set of host-owned projects (from `tenexPrivateKey` + project `event.json`) into relay `a`-tag filters. |
+| `relay.rs` / `cursor.rs` / `accumulator.rs` | Relay connection, persisted relay-walk cursor, and deduplicated event accumulation. The source of truth is relay kind:1 events, not `conversation.db`. |
 | `state.rs` | `~/.tenex/embedder/state.db` — three-cursor per-conversation embed state plus `child_set_hash` and `summary_hash` fingerprints. |
 | `target.rs` | Write side: stable chunk IDs, `RagStore::put` / `delete_by_source` / `delete_by_id` wrappers. |
 | `transcript.rs` | Speaker rendering, `AgentDirectory` name resolution chain (project agent → pubkey hex), merged stream construction. |

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Agents can define phases (for example: planning, execution, review) to structure
 
 ### Prerequisites
 
-- **Node.js** 20+ or **Bun** runtime (recommended for development)
+- A **Rust toolchain** (stable, via [rustup](https://rustup.rs))
 - **Git** for version control integration
-- An API key for at least one LLM provider (OpenAI, Anthropic, etc.)
+- An API key for at least one LLM provider (OpenAI, Anthropic, OpenRouter, …)
 
 ### Installation
 
@@ -65,23 +65,26 @@ Agents can define phases (for example: planning, execution, review) to structure
 git clone https://github.com/tenex-chat/tenex
 cd tenex
 
-# Install dependencies
-bun install
+# Build the workspace
+cargo build --release
 ```
+
+The `tenex` binary is produced at `target/release/tenex`.
 
 ### Configuration
 
-Before you can start using TENEX, you need to set up your LLM provider credentials.
-From the repo, run:
+Before using TENEX, run the setup wizard to configure your identity, relays, and
+LLM provider credentials:
 
 ```bash
-bun run start -- setup
+tenex onboard
 ```
 
-If you install the daemon launcher from npm, run:
+Then start the project supervisor, which subscribes to Nostr and spawns a
+runtime per project on inbound events:
 
 ```bash
-npx @tenex-chat/daemon
+tenex daemon
 ```
 
 ### Quick Start
@@ -102,28 +105,40 @@ TENEX: [System routes to Planner]
 
 ## 📚 Documentation
 
-- **[Architecture](./docs/ARCHITECTURE.md)**: Core principles, layered architecture, and module organization.
+- **[Architecture](./docs/ARCHITECTURE.md)**: Core principles, the Rust crate workspace, and module organization.
+- **[crates/AGENTS.md](./crates/AGENTS.md)**: Modularization philosophy and the rules for adding or splitting crates.
+- **[Module Inventory](./MODULE_INVENTORY.md)**: Canonical map of every crate and its internal modules.
 - **[Contributing](./docs/CONTRIBUTING.md)**: Development workflow, coding guidelines, and testing.
-- **[Testing Status](./docs/TESTING_STATUS.md)**: Current state of the test suite and future improvements.
-- **[NDK Testing](./docs/testing-with-ndk.md)**: How to use Nostr Development Kit utilities for testing.
-- **[Worktrees](./docs/worktrees.md)**: Guide to using Git worktrees for parallel development.
 
 ## 🏗️ Project Structure
 
+TENEX is a Rust workspace. The host CLI/supervisor lives in `tenex/`; every
+other concern is a focused crate under `crates/`. See
+[MODULE_INVENTORY.md](./MODULE_INVENTORY.md) for the full map.
+
 ```
-src/
-├── agents/         # Agent definitions and execution runtime
-├── commands/       # User-facing CLI commands
-├── conversations/  # Conversation history and state management
-├── daemon/         # Long-running background processes and UI
-├── events/         # Core event schemas and constants
-├── lib/            # Pure, framework-agnostic utilities (zero TENEX dependencies)
-├── llm/            # LLM provider abstractions and factories
-├── nostr/          # Nostr protocol integration and clients
-├── prompts/        # System prompt composition and management
-├── services/       # Stateful business logic and orchestration
-├── tools/          # Agent tool implementations and registry
-└── utils/          # TENEX-specific helper functions
+tenex/                     # Host CLI + supervisor: onboarding, config, doctor, daemon, runtime, agent/mcp/cron commands
+crates/
+├── tenex-agent/           # One-shot agent runner: LLM loop + tools (NDJSON over stdio)
+├── tenex-conversations/   # SQLite conversation store (messages, prompt history, completions, delegations)
+├── tenex-context/         # Conversation-history → LLM-message projection
+├── tenex-system-prompt/   # Deterministic system-prompt assembly
+├── tenex-project/         # Read-side project view: membership, teams, signer
+├── tenex-agent-registry/  # Global installed-agent JSON registry
+├── tenex-llm-config/      # LLM/provider configuration resolver
+├── tenex-mcp/             # Project-scoped MCP server runtime
+├── tenex-rag/             # RAG storage + embeddings
+├── tenex-summarizer/      # kind:513 conversation-metadata daemon
+├── tenex-embedder/        # Conversation embedding daemon
+├── tenex-scheduler/       # Cron / schedule daemon
+├── tenex-intervention/    # Completion-timeout watcher daemon
+├── tenex-identity/        # kind:0 profile resolver + cache
+├── tenex-telegram/        # Telegram integration
+├── tenex-protocol/        # TENEX intent vocabulary + Nostr channel encoding
+├── tenex-whitelist/       # Local trust-set reader
+├── tenex-supervision/     # Pure supervision heuristics (no I/O)
+├── tenex-telemetry/       # OpenTelemetry / tracing bootstrap
+└── tenex-accounting/      # LLM accounting store + embedded UI
 ```
 
 ## 🤝 Contributing
@@ -133,24 +148,23 @@ We welcome contributions! Please read our [**Contributing Guide**](./docs/CONTRI
 ### Development Setup
 
 ```bash
-# Install dependencies
-bun install
+# Build the workspace
+cargo build
 
-# Run tests
-bun test
+# Run the test suite
+cargo test --workspace
 
-# Run tests in watch mode
-bun test --watch
+# Lint (deny warnings)
+cargo clippy --workspace --all-targets
 
-# Run type checking
-bun run typecheck
+# Format
+cargo fmt --all
 
-# Run architecture linting
-bun run lint:architecture
-
-# Build for production
-bun run build
+# Build optimized binaries
+cargo build --release
 ```
+
+The pre-commit hook runs `cargo check --workspace`.
 
 ## 🔮 What Makes TENEX Different?
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,500 +1,234 @@
 # TENEX Architecture Guide
 
-## Table of Contents
-- [Core Principles](#core-principles)
-- [Layered Architecture](#layered-architecture)
-- [Module Organization](#module-organization)
-- [Naming Conventions](#naming-conventions)
-- [Import Patterns](#import-patterns)
-- [Adding New Code](#adding-new-code)
-- [Anti-Patterns to Avoid](#anti-patterns-to-avoid)
+TENEX is a multi-agent AI coordination system built on Nostr. It is a **Rust
+workspace**: a set of focused crates that decompose the system into libraries,
+daemons, and one-shot binaries, plus the `tenex` host CLI/supervisor.
 
-Related architecture notes:
+This document is the human-readable orientation. Two companion documents are
+authoritative and should be kept in sync with it:
 
-- `docs/system-prompt-architecture.md` covers how TENEX builds the base system prompt.
-- `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md` covers request-time context management, reminders, and prompt-history overlays.
-- `docs/SUPERVISION.md` covers supervision heuristics, post-completion gating, retry semantics, and structured resolution paths.
-- `docs/plans/2026-04-28-architecture-map.md` covers Rust workspace crates, including the JSON-backed installed-agent registry.
+- **`crates/AGENTS.md`** — the modularization philosophy and the non-negotiable
+  rules for adding, splitting, or merging crates.
+- **`MODULE_INVENTORY.md`** — the canonical map of every crate and its internal
+  modules. Consult it before writing code.
+
+Related notes:
+
+- `docs/system-prompt-architecture.md` — how an agent's system prompt is assembled.
+- `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md` — request-time context management, reminders, prompt-history overlays.
+- `docs/SUPERVISION.md` — supervision heuristics, post-completion gating, retry semantics.
+- `docs/plans/2026-04-28-architecture-map.md` — the migration map and target end state.
 
 ---
 
 ## Core Principles
 
-### 1. **Unidirectional Dependencies**
-Dependencies flow **downward only**, never upward:
+### 1. One crate, one thing
+Each crate does a single job: a storage layer, a projection, a subsystem of the
+host daemon, or a one-shot binary. Not a kitchen sink. New behavior extends the
+crate that already owns the concern; it does not accrete into an unrelated one.
 
-```
-commands/daemon/event-handler → services/agents/conversations/tools
-  ↓
-llm/nostr/prompts/events
-  ↓
-utils
-  ↓
-lib
-```
+### 2. Composition through narrow contracts
+Crates compose through explicit contracts, never through inheritance or shared
+globals. Two contracts dominate the tree:
 
-**Rule:** Lower layers never import from higher layers.
+- **Storage contract by substrate.** SQLite-backed crates expose a typed Rust
+  API over a versioned, forward-only schema. JSON-backed crates expose typed
+  APIs over a documented file layout. Multiple processes open the same durable
+  state directly — there is no service in front and no IPC layer for storage.
+- **NDJSON over Unix sockets** (and over stdio for one-shots) is the canonical
+  local IPC. The same frame format applies whether the peer is a subprocess or
+  a long-lived daemon. `tenex-agent` already speaks NDJSON over stdio.
 
-### 2. **Pure Utilities in lib/**
-The `lib/` layer contains **zero TENEX-specific code**. These are pure, reusable utilities that could work in any Node.js project:
-- Filesystem operations
-- String manipulation
-- Time formatting
-- Validation helpers
-- Error formatting
+Typed APIs within a process; text streams between processes.
 
-**Rule:** `lib/` has NO imports from `utils/`, `services/`, or any TENEX modules.
+### 3. Three roles, kept separate
+Anything that touches relays + LLM + tools must keep these apart:
 
-### 3. **TENEX-Specific Utilities in utils/**
-The `utils/` layer contains helpers specific to TENEX's domain:
-- Nostr entity parsing
-- Phase management
-- Git operations
-- Conversation utilities
+- **Subscribe** — owns the relay connection.
+- **Orchestrate** — owns dispatch, RAL state, and the delegation tree.
+- **Execute** — owns the LLM loop and tools (`tenex-agent`).
 
-**Rule:** `utils/` can import from `lib/` but not from `services/` or higher layers.
+The runner does not open relays. The orchestrator does not call LLMs. The
+subscriber does not track delegations. Collapsing these is the single biggest
+design failure mode in this codebase.
 
-### 4. **Business Logic in services/**
-The `services/` layer contains stateful business logic and domain services:
-- Configuration management
-- RAG operations
-- Scheduling
-- Delegation/RAL state tracking
-- MCP integration
-
-**Rule:** Services can import from `utils/`, `lib/`, `nostr/`, `llm/`, but not from `commands/`, `daemon/`, or `event-handler/`.
+### 4. Crash and restart are normal
+State lives on disk. In-memory caches are caches, not the truth. Every process
+must survive being killed and restarted from SQLite or filesystem state.
 
 ---
 
-## Layered Architecture
+## Workspace Shape
 
-### Layer 0: Platform Primitives (`lib/`)
-**Purpose:** Framework-agnostic utilities
+The host CLI/supervisor lives in `tenex/` (package `tenex`). Everything else is
+a crate under `crates/`. See `MODULE_INVENTORY.md` for the authoritative list;
+the roles below are a summary.
 
-**Contains:**
-- `lib/fs/` - Filesystem operations
-- `lib/string.ts` - String utilities
-- `lib/error-formatter.ts` - Error formatting
-- `lib/time.ts` - Time utilities
+### Library crates (no daemon — just typed APIs)
 
-**Dependencies:** Node.js built-ins, npm packages only
+| Crate | Owns |
+|---|---|
+| `tenex-conversations` | SQLite conversation store: messages, tool messages, prompt history, completions, delegations, context state, and migration from older disk formats. |
+| `tenex-agent-registry` | JSON-backed global installed-agent registry under `<base_dir>/agents`: document normalization, mutation, keys, index maintenance. |
+| `tenex-project` | Read-side project view over project event JSON and agent JSON: id normalization, membership projection, teams, signer selection. |
+| `tenex-context` | Conversation-history → LLM-message projection: message shaping, token estimates, cache-breakpoint hints, context-management turn recording. |
+| `tenex-system-prompt` | Deterministic system-prompt assembly from agent identity, project context, and skill references. |
+| `tenex-identity` | `pubkey → IdentityView` resolution via kind:0 plus a host-wide cache. |
+| `tenex-llm-config` | Filesystem-backed LLM/provider configuration resolver, including meta/inline model resolution and API-key health. |
+| `tenex-mcp` | Project-scoped MCP server lifecycle, tool manifests, and the runtime↔agent Unix-socket bridge. |
+| `tenex-rag` | RAG configuration, embeddings, and SQLite-backed vector/document storage. |
+| `tenex-protocol` | Transport-agnostic TENEX intent vocabulary and Nostr channel encoding. |
+| `tenex-supervision` | Pure supervision heuristics for the agent runner: no I/O, no async. |
+| `tenex-whitelist` | Local trust-set reader for whitelisted users and project p-tags. |
+| `tenex-telemetry` | Shared OpenTelemetry/`tracing` bootstrap and context propagation. |
+| `tenex-accounting` | SQLite-backed LLM accounting/observability store plus an embedded local UI. |
 
-**Example:**
-```typescript
-// ✅ Good - pure utility
-export function toKebabCase(str: string): string {
-    return str.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
-}
+### Daemons (long-lived)
 
-// ❌ Bad - depends on TENEX code
-import { config } from "@/services/ConfigService";
-```
+| Daemon | Owns |
+|---|---|
+| `tenex daemon` (supervisor) | Boots and supervises project runtimes and host companion daemons on inbound events. |
+| `tenex-summarizer` | Generates kind:513 conversation metadata across projects. |
+| `tenex-embedder` | Reads kind:1 events from the relays for the host's owned projects and embeds the conversation transcripts into the global RAG store (`embeddings.db`). |
+| `tenex-scheduler` | Schedule/cron firing for scheduled and one-off tasks. |
+| `tenex-intervention` | Human-replica review when an agent completion times out. |
+| `tenex-identity` | Resolves and caches kind:0 profile data host-wide. |
+| `tenex-telegram` | Telegram integration: bot client, bindings, polling, rendering, event synthesis. |
 
----
+### One-shot / pure-compute binaries
 
-### Layer 1: TENEX Utilities (`utils/`)
-**Purpose:** Domain-specific helpers
-
-**Contains:**
-- `utils/nostr-entity-parser.ts` - Nostr parsing utilities
-- `utils/git/` - Git operations (including worktree management)
-- `utils/phase-utils.ts` - Phase management
-- `utils/conversation-id.ts` - Conversation identifier helpers
-- `utils/logger.ts` - Logging (can depend on services/config)
-
-**Dependencies:** `lib/`, Node.js built-ins, npm packages
-
-**Example:**
-```typescript
-// ✅ Good - TENEX-specific helper using lib utilities
-import { formatAnyError } from "@/lib/error-formatter";
-
-export function parseNostrUser(input: string): { pubkey: string } | null {
-    // ... implementation
-}
-```
+| Binary | Owns |
+|---|---|
+| `tenex-agent` | Single-turn agent runner. Reads one Nostr event over stdin, runs the LLM/tool loop, emits signed NDJSON frames over stdout. **Does not open relays.** |
+| `tenex whitelist check` | Single trust check from the shell. |
+| `tenex doctor` | Diagnostics and one-time migration/repair workflows. |
 
 ---
 
-### Layer 2: Protocol & Abstraction Layers
-**Modules:** `events/`, `nostr/`, `llm/`, `prompts/`
+## Library vs Daemon — the decision rule
 
-**Purpose:** Protocol implementations and provider abstractions
+Process boundaries cost something. Take one only when you get at least one of:
+concurrency isolation, security isolation, language choice, independent restart,
+or hot-swap. Otherwise it is a library, not a daemon.
 
-**Dependencies:** `utils/`, `lib/`
+| Want | Make it a… |
+|---|---|
+| Typed state shared across processes | Library + SQLite (`tenex-conversations`) |
+| Global installed-agent JSON shared across processes | Library + JSON files (`tenex-agent-registry`) |
+| Read-side project metadata and membership | Library + JSON files (`tenex-project`) |
+| LLM-bound or stateful work that should survive runtime restarts | Daemon (`tenex-summarizer`, `tenex-scheduler`, `tenex-intervention`) |
+| Pure compute reachable over a frame protocol | One-shot or long-lived binary (`tenex-agent`) |
 
----
-
-### Layer 3: Domain Logic
-**Modules:** `services/`, `agents/`, `conversations/`, `tools/`
-
-**Purpose:** Business logic, state management, capabilities
-
-**Notes:** Tools stay stateless even when they are runtime-gated. Context-injected capabilities such as `send_message` belong in `src/tools/registry.ts` and must delegate transport work to services like `src/services/telegram/TelegramDeliveryService`. Within the conversation domain, canonical transcripts remain JSON in `ConversationStore`, while metadata-style reads belong on the per-project SQLite catalog in `ConversationCatalogService`. Prompt and tool code should query that catalog or `ConversationRegistry` compatibility APIs instead of reparsing transcript files.
-
-Teams are a local-only service concern. `src/services/teams/` loads JSON definitions from disk, normalizes membership, resolves team names to lead agents for delegation, and feeds prompt-facing team summaries into the prompt layer. Team scope itself is carried across Nostr via `["team", "..."]` tags, not via team objects in relay state.
-
-**Dependencies:** Everything below (layers 0-2)
+A daemon's public surface is a Unix socket speaking NDJSON. A library's public
+surface is a typed Rust API over its substrate. Pick one; never both.
 
 ---
 
-### Layer 4: Application Entry Points
-**Modules:** `commands/`, `daemon/`, `event-handler/`
+## Cross-Cutting Contracts
 
-**Purpose:** CLI, runtime orchestration, event routing
+These hold across every crate. Violations are bugs.
 
-**Dependencies:** Everything below (layers 0-3)
-
----
-
-## Module Organization
-
-### Services Directory Structure
-
-Services should be organized by domain, with related code grouped together:
-
-```
-services/
-├── analysis/            # LLM telemetry schema, migrations, and query services
-├── migrations/          # Explicit TENEX state migrations keyed by config.json version
-├── dispatch/             # Chat routing + delegation dispatch
-│   ├── AgentDispatchService.ts
-│   ├── AgentRouter.ts
-│   └── DelegationCompletionHandler.ts
-├── ral/                  # Delegation/RAL state
-│   ├── RALRegistry.ts
-│   ├── DelegationRegistry.ts
-│   ├── KillSwitchRegistry.ts
-│   ├── HeuristicViolationManager.ts
-│   ├── MessageInjectionQueue.ts
-│   ├── ExecutionTimingTracker.ts
-│   ├── types.ts
-│   └── index.ts
-├── teams/                # Local team definitions, prompt context, and delegate resolution
-├── rag/                  # RAG domain
-│   ├── RAGService.ts
-│   ├── RAGDatabaseService.ts
-│   ├── RagSubscriptionService.ts
-│   ├── ...
-│   └── index.ts
-├── projects/
-├── scheduling/
-├── reports/
-├── mcp/
-└── ...
-```
-
-**When to create a subdirectory:**
-- 3+ related files
-- Distinct domain boundary
-- Internal implementation details to hide
-
-**Small services (1-2 files):** Keep at top level until they grow.
-
-### Conversation Read Models
-
-TENEX conversation storage has two intentional layers:
-
-- `ConversationStore` is the canonical ledger. It owns full transcript JSON, context-management compactions, and save/load semantics.
-- `ConversationCatalogService` is the per-project derived read model backed by `conversation-catalog.db`. It exists for prompt/tool metadata queries such as recent conversations, conversation previews, participant/delegation lookups, and durable embedding indexing state.
-
-`ConversationStore` also carries per-agent prompt-view state that is intentionally separate from the canonical transcript:
-
-- Canonical `ConversationRecord`s remain the source of truth for transcript history.
-- Per-agent frozen prompt histories record the exact pre-context-management prompt view previously sent to that agent. Runtime-only system reminder overlays remain ephemeral until a request has actually established prompt caching; after that anchor exists they can be persisted as replayable prompt-history entries.
-- Runtime overlays must never be replayed by mutating historical transcript messages. Append them as prompt-history entries instead.
-
-When adding a new conversation-facing feature, decide explicitly which layer it belongs to:
-
-- If it needs the full transcript or mutates canonical conversation state, use `ConversationStore`.
-- If it only needs queryable metadata or list/filter behavior, use the catalog. Do not add new transcript-scanning helpers for those paths.
-
-### Teams
-
-Teams are local JSON-defined memberships that never become standalone Nostr entities. The runtime resolves them from disk through `src/services/teams/TeamService.ts`, which normalizes the team lead into membership, caches by file state, and resolves team names to lead pubkeys for delegation.
-
-- Team definitions stay local on disk and are not published as Nostr events.
-- Delegation events carry team scope through the `["team", "..."]` tag.
-- Prompt rendering uses team membership to filter `<available-agents>`: when teams are defined, only the active team's teammates and unaffiliated agents are detailed; other teams appear as one-line summaries.
-- Team names are resolved case-insensitively, with agent slugs still taking priority when a recipient string matches both.
-
----
-
-### Supporting Tooling
-
-Standalone developer tooling or auxiliary CLIs should live under `tools/` at the repo root. Treat each tool as isolated (own `package.json`/`tsconfig.json`) and document additions in `MODULE_INVENTORY.md`.
+- **Project IDs accept either form.** Public APIs that take a project identifier
+  accept the full NIP-33 coordinate (`31933:<pubkey>:<dTag>`) or the bare dTag.
+  Normalize once at the boundary, with the owning crate (`tenex-project` /
+  `tenex-conversations`) — not repeatedly at call sites.
+- **Schema or file layout is the contract.** SQLite migrations are forward-only
+  and versioned, and belong only to the crate that owns the database. JSON
+  file-layout changes belong only to the crate that owns that directory.
+- **Signing is behind the `Signer` trait.** One implementation today (`nsec:`),
+  one tomorrow (`bunker:` / NIP-46). A single swap when the bunker lands.
+- **MCP is project-scoped.** Server definitions live in the project working
+  directory's `.mcp.json`; agent JSON grants access. There is no host-global
+  MCP server registry, and MCP discovery/runtime belongs in `tenex-mcp`.
+- **Agent execution belongs in `tenex-agent`.** Relay subscription and runtime
+  orchestration belong outside the agent runner.
+- **Prompt assembly belongs in `tenex-system-prompt`; message-stream projection
+  belongs in `tenex-context`.**
+- **RAG: agents add documents by audience scope only.** Do not add
+  collection-management tools back into the agent surface.
+- **Lessons are not in the storage crates.** They are out of scope for
+  `tenex-project`, `tenex-agent-registry`, and `tenex-conversations`.
 
 ---
 
 ## Naming Conventions
 
-### Services
-**Preferred suffix:** `Service`
+| Thing | Convention | Example |
+|---|---|---|
+| Crates | `tenex-<area>`, kebab-case | `tenex-conversations` |
+| Crate package name | matches the directory | `tenex-conversations` |
+| Modules / files | snake_case `.rs` | `schema.rs`, `store.rs` |
+| Types | `CamelCase` | `ConversationStore`, `IdentityView` |
+| Functions / fields | snake_case | `list_candidates`, `last_activity` |
+| Tests | `#[cfg(test)]` modules or `tests/*.rs` | `tests/discover_and_read.rs` |
 
-```typescript
-// ✅ Preferred
-ConfigService
-RAGService
-SchedulerService
-ProjectStatusService
-
-// ✅ Most business-logic classes use the "Service" suffix.
-```
-
-**Goal:** Consistent "Service" suffix for all business logic classes.
-
-**Exceptions:** Registries (e.g., `RALRegistry`) keep their names when they are not business-logic services.
+Each crate carries an `AGENTS.md` describing its local invariants. Read it
+before changing that crate.
 
 ---
 
-### File Naming
-- **Services:** `SomethingService.ts` (PascalCase)
-- **Utilities:** `kebab-case.ts` or `camelCase.ts` (be consistent within a directory)
-- **Types:** `types.ts` or `Something.types.ts`
-- **Tests:** `Something.test.ts` (co-located in `__tests__/`)
+## Dependencies
+
+- Crate dependencies are declared in each crate's `Cargo.toml` and the workspace
+  `Cargo.toml`. Keep the dependency graph acyclic and minimal.
+- The whole tree is **Rust-only**. There are no `bun`/TypeScript imports.
+  Cross-language state sharing, where it still exists during migration, happens
+  only through the shared SQLite schemas or JSON file layouts on disk — never
+  through code imports.
+- Pure, no-I/O logic (e.g. supervision heuristics in `tenex-supervision`) stays
+  free of async and workspace dependencies so it can be unit-tested in isolation.
 
 ---
 
-## Import Patterns
+## Before Writing Code
 
-### Rule 1: No Barrel Exports for Services
-**Do NOT** use `services/index.ts` barrel export. Import directly from service directories:
+Three questions, in order (from `crates/AGENTS.md`):
 
-```typescript
-// ✅ Good - direct import
-import { RALRegistry } from "@/services/ral";
-import { RAGService } from "@/services/rag";
+1. **Does an existing crate already own this concern?** If yes, extend it.
+2. **Is this a new role in the fleet, or a new instance of an existing role?**
+   New role → new crate. New instance → the existing home for that role.
+3. **Library or daemon?** Apply the decision rule above. If undecided, it is a
+   library.
 
-// ❌ Bad - barrel import
-import { RALRegistry, RAGService } from "@/services";
-```
-
-**Why:**
-- Explicit dependencies
-- Better tree-shaking
-- Faster TypeScript compilation
-- No barrel maintenance
-
-### Rule 2: Subdirectories Control Their Exports
-Each service subdirectory has an `index.ts` that controls what's public:
-
-```typescript
-// services/ral/index.ts
-export { RALRegistry } from "./RALRegistry";
-export type { PendingDelegation, CompletedDelegation } from "./types";
-```
-
-### Rule 3: Use @/ Alias
-Always use the `@/` path alias for absolute imports:
-
-```typescript
-// ✅ Good
-import { config } from "@/services/ConfigService";
-import { formatAnyError } from "@/lib/error-formatter";
-
-// ❌ Bad - relative imports for cross-module
-import { config } from "../../../services/ConfigService";
-```
+If all three point to "yes, new crate," update both
+`docs/plans/2026-04-28-architecture-map.md` and the workspace `Cargo.toml` in
+the same change, and add the crate's `AGENTS.md`.
 
 ---
 
-## Adding New Code
+## Anti-Patterns to Reject
 
-### Adding a New Utility
-
-**1. Determine if it's pure or TENEX-specific:**
-- **Pure** (no TENEX deps) → `lib/`
-- **TENEX-specific** → `utils/`
-
-**2. Create the file:**
-```typescript
-// lib/array-utils.ts (pure utility)
-export function chunk<T>(array: T[], size: number): T[][] {
-    // ... implementation
-}
-```
-
-**3. Prefer direct imports.** Add an `index.ts` only when a subdirectory needs an explicit public surface.
+- **Collapsing the three roles.** A runner that opens relays, or an orchestrator
+  that calls an LLM, breaks the fleet model.
+- **A daemon that also exposes a typed storage API**, or a library that also
+  runs a socket. Pick one public surface.
+- **Re-normalizing project IDs at every call site** instead of once at the
+  owning crate's boundary.
+- **Sentinel values that mask failure.** `"unknown"`, `String::new()`, `0`, or
+  `unwrap_or(None)` on a `Result<Option<T>>` silently convert errors into
+  "not found". Represent absence with `Option`; propagate or log-and-bail on
+  failure.
+- **Backwards-compatibility shims past a single bounded cutover.** No `_unused`
+  prefixes, no commented-out blocks, no "temporary" code.
 
 ---
 
-### Adding a New Service
+## Discipline
 
-**1. Decide if it needs a subdirectory:**
-- **Yes** if: 3+ related files, distinct domain
-- **No** if: 1-2 files, simple service
-
-**2. Create the service:**
-```typescript
-// services/notifications/NotificationService.ts
-import { config } from "@/services/ConfigService";
-import { logger } from "@/utils/logger";
-
-export class NotificationService {
-    constructor(
-        private readonly config: typeof config,
-        private readonly logger: typeof logger
-    ) {}
-
-    // Methods...
-}
-
-// Export default instance for convenience
-export const notificationService = new NotificationService(config, logger);
-```
-
-**3. Create index.ts:**
-```typescript
-// services/notifications/index.ts
-export { NotificationService, notificationService } from "./NotificationService";
-export type { NotificationOptions } from "./types";
-```
-
-**4. Import where needed:**
-```typescript
-import { notificationService } from "@/services/notifications";
-```
-
----
-
-### Adding to Existing Layers
-
-**Adding to lib/:**
-- Must be pure, no TENEX dependencies
-- No imports from `utils/`, `services/`, etc.
-- Use console.error instead of TENEX logger
-
-**Adding to utils/:**
-- Can import from `lib/`
-- Should be domain helpers, not business logic
-- If it needs state, it should be a service instead
-
-**Adding to services/:**
-- Can import from `utils/`, `lib/`, `nostr/`, `llm/`, `prompts/`, `events/`
-- Cannot import from `commands/`, `daemon/`, `event-handler/`
-
----
-
-## Anti-Patterns to Avoid
-
-### ❌ Circular Dependencies
-```typescript
-// lib/something.ts
-import { logger } from "@/utils/logger";  // ❌ lib → utils (wrong direction)
-
-// utils/helper.ts
-import { someService } from "@/services/SomeService";  // ❌ utils → services
-```
-
-**Solution:** Move code to correct layer or use dependency injection.
-
----
-
-### ❌ Barrel Export Bypass
-```typescript
-// ❌ Importing from barrel when subdirectory exists
-import { RAGService } from "@/services";
-
-// ✅ Import directly from subdirectory
-import { RAGService } from "@/services/rag";
-```
-
----
-
-### ❌ Business Logic in Utilities
-```typescript
-// ❌ Bad - stateful service masquerading as utility
-// utils/user-manager.ts
-export class UserManager {
-    private users: Map<string, User> = new Map();
-    // ... state management
-}
-```
-
-**Solution:** Move to `services/` if it has state or business logic.
-
----
-
-### ❌ Inconsistent Naming
-Avoid mixing naming styles for the same layer. Use `Service` for business logic, and reserve `Registry`/`Manager` for registries or infrastructure helpers.
-
----
-
-## Dependency Injection Pattern
-
-**Recommended pattern for services:**
-
-```typescript
-// services/something/SomethingService.ts
-export class SomethingService {
-    // Declare dependencies in constructor
-    constructor(
-        private readonly config: typeof config,
-        private readonly logger: typeof logger,
-        private readonly someOtherService: SomeOtherService
-    ) {}
-
-    doSomething(): void {
-        // Use injected dependencies
-        const value = this.config.getConfigPath();
-        this.logger.info("Doing something", { value });
-    }
-}
-
-// Export default instance for convenience
-import { config } from "@/services/ConfigService";
-import { logger } from "@/utils/logger";
-import { someOtherService } from "@/services/some-other";
-
-export const somethingService = new SomethingService(
-    config,
-    logger,
-    someOtherService
-);
-```
-
-**Benefits:**
-- Testable (inject mocks)
-- Clear dependencies
-- No hidden singletons
-- Convenient default instance
-
----
-
-## Evolution Strategy
-
-### Completed Improvements
-
-- **Pure Utilities in `lib/`**: All pure, framework-agnostic utilities are now isolated in the `lib/` directory with zero TENEX dependencies.
-- **No Circular Dependencies**: All circular dependencies between layers have been resolved.
-- **Consistent Service Naming**: All services have been refactored to use the `Service` suffix, removing legacy names like `ReportManager` and `PubkeyNameRepository`.
-- **Git Utilities Consolidated**: All Git-related helpers, including worktree management, are now centralized in `utils/git/`.
-- **Configuration Architecture**: A centralized `ConfigService` now manages all configuration, ensuring consistent and predictable settings management.
-
-### Target State
-
-**We are incrementally moving toward:**
-1. ⏳ **Subdirectory Grouping for Services**: Gradually group related services into subdirectories for better organization.
-2. ⏳ **Dependency Injection Pattern**: Continue to adopt dependency injection for all services to improve testability and clarity.
-3. ⏳ **Removal of Barrel Exports**: Phase out all remaining barrel exports in favor of direct imports.
-
-**Philosophy:** Make incremental improvements. Leave code better than you found it (Boy Scout Rule).
-
----
-
-## Questions?
-
-If unsure where code belongs:
-1. Is it pure/framework-agnostic? → `lib/`
-2. Is it a TENEX helper with no state? → `utils/`
-3. Does it manage state or business logic? → `services/`
-4. Is it protocol-specific? → `nostr/`, `llm/`, etc.
-
-When in doubt, **ask in PR review** or **check this document**.
+- **Simplicity over complexity, every time.** An abstraction earns its place by
+  serving two or more concrete consumers — never one, never speculative.
+- **Repetition is a hard boundary.** Three similar lines is fine; the third copy
+  of a real pattern is a refactor, not optional.
+- **Zero accumulation of technical debt.** If the right fix is hard, do the hard
+  thing. Speed is not a value here; coherence is.
+- **Boy Scout Rule.** Leave every file better than you found it — fix the stale
+  comment or off-pattern name nearby, without widening scope into a refactor PR.
 
 ---
 
 ## See Also
-- [CONTRIBUTING.md](./CONTRIBUTING.md) - Development workflow
-- [MODULE_INVENTORY.md](../MODULE_INVENTORY.md) - Current module list
-- [TESTING_STATUS.md](./TESTING_STATUS.md) - Testing guidelines
+- [crates/AGENTS.md](../crates/AGENTS.md) — modularization philosophy and rules.
+- [MODULE_INVENTORY.md](../MODULE_INVENTORY.md) — canonical crate and module map.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — development workflow.
+- [docs/plans/2026-04-28-architecture-map.md](./plans/2026-04-28-architecture-map.md) — migration map and target end state.

--- a/docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md
+++ b/docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md
@@ -1,324 +1,119 @@
 # TENEX Context Management And Reminders
 
-This document explains how request-time context management works in TENEX after reminder handling was merged into `ai-sdk-context-management`.
+This document explains how TENEX shapes the message list sent to the LLM on each
+turn: context-window management (compaction, tool-result decay), delegation-marker
+expansion, proactive RAG context, and reminders.
 
 The short version:
 
-- TENEX keeps the canonical transcript immutable.
-- TENEX keeps a separate per-agent prompt-view history of what was actually sent.
-- Reminders are computed at request time by `RemindersStrategy`.
-- Runtime-only reminders are stored as append-only prompt overlays, not as edits to old user messages.
-- Cold prompt histories are restored from canonical transcript content before each request, so non-cached providers do not keep replaying stale reminder-appended user turns.
-
-## Design Invariants
-
-These rules are intentional and should not be broken by future refactors:
-
-1. Canonical conversation history is the source of truth for the transcript.
-2. Historical prompt state is append-only per agent.
-3. Runtime reminders must not rewrite historical transcript messages.
-4. Reminder delta/full bookkeeping is separate from prompt-history storage.
-
-The bug that drove this design was prompt corruption from repeatedly appending runtime reminder content into older user messages. That caused prompt drift, duplicated reminder blocks, and unbounded prompt growth. The current architecture exists to prevent that.
-
-## Main Pieces
-
-### TENEX runtime wiring
-
-- `src/agents/execution/context-management/runtime.ts`
-- `src/agents/execution/request-preparation.ts`
-- `src/agents/execution/StreamSetup.ts`
-- `src/agents/execution/StreamCallbacks.ts`
-
-TENEX constructs an `ai-sdk-context-management` runtime per execution context and passes current request facts into it.
-
-### Library strategies
-
-- `ai-sdk-context-management/src/strategies/reminders/index.ts`
-
-`RemindersStrategy` owns reminder production and placement.
-
-### TENEX reminder providers
-
-- `src/agents/execution/system-reminders.ts`
-
-TENEX supplies provider-specific reminder facts and reminder renderers for:
-
-- `datetime`
-- `todo-list`
-- `response-routing`
-- `delegations`
-- `conversations`
-- `loaded-skills`
-
-Non-loaded skills are not exposed through a system reminder. Agents must use `skill_list` to discover available skills on demand.
-
-TENEX also enables the library-owned built-in reminder sources for:
-
-- context utilization
-- context-window status
-
-### Runtime-only reminder queue
-
-- `src/llm/system-reminder-context.ts`
-
-This is an `AsyncLocalStorage` queue for current-cycle reminders such as supervision corrections or one-shot runtime notices. It supports:
-
-- `queue(...)`
-- `defer(...)`
-- `advance()`
-- `collect()`
-
-This queue is not the main reminder engine. It is an ingress path for transient reminders that should affect the current or next request without being written into the canonical transcript.
-
-For the supervision side of this flow, see `docs/SUPERVISION.md`. That document explains where `supervision-correction` and `supervision-message` reminders come from and why some supervision violations re-engage the agent immediately while others only queue a later reminder.
-
-### Persistence
-
-- `src/conversations/ConversationStore.ts`
-- `src/conversations/types.ts`
-
-TENEX persists three different kinds of state:
-
-1. Canonical transcript state
-2. Per-agent prompt history
-3. Per-agent reminder engine state
-
-Those are separate on purpose.
-
-## End-To-End Request Flow
-
-### 1. Compile canonical prompt material
-
-`MessageCompiler` compiles the canonical conversation projection for the current turn.
-
-That output is still canonical conversation state. It does not yet include request-time overlays from context management.
-
-### 2. Promote deferred current-cycle reminders
-
-At the start of execution, `StreamSetup.ts` calls:
-
-```ts
-getSystemReminderContext().advance();
-```
-
-This promotes reminders that were deferred from the previous cycle into the current queued reminder set.
-
-### 3. Build `reminderData`
-
-TENEX assembles current turn facts in `StreamSetup.ts` or `StreamCallbacks.ts`, including:
-
-- the agent
-- the conversation store
-- the responding principal
-- pending and completed delegations
-- rendered conversation summary content
-- loaded skills
-- skill tool permissions
-- project path
-
-This object is passed into context management as `reminderData`.
-
-### 4. Build prompt history from canonical messages only
-
-Before context management runs, TENEX calls:
-
-- `buildPromptHistoryMessages(...)` in `src/agents/execution/prompt-history.ts`
-
-This appends any newly visible canonical messages into the agent's frozen prompt history.
-
-Important: this first pass does not inject runtime overlays yet.
-
-### 5. Prepare the provider-facing request
-
-`prepareLLMRequest(...)` in `src/agents/execution/request-preparation.ts` does the request-time transformation step.
-
-It:
-
-1. normalizes legacy message shapes
-2. collects queued current-cycle reminders from `getSystemReminderContext().collect()`
-3. maps them into `queuedReminders`
-4. calls `contextManagement.prepareRequest(...)`
-
-At this point TENEX passes two reminder inputs into the library:
-
-- `reminderData`: the persistent, domain-level facts for the turn
-- `queuedReminders`: transient current-cycle reminders from the async reminder context
-
-### 6. Strategy stack runs inside `ai-sdk-context-management`
-
-In `src/agents/execution/context-management/runtime.ts`, TENEX currently wires a stack shaped like:
-
-1. `CompactionToolStrategy` when enabled
-2. `ToolResultDecayStrategy` when enabled
-3. `RemindersStrategy` when enabled
-
-The exact toggles come from `src/agents/execution/context-management/settings.ts`.
-
-### 7. `RemindersStrategy` computes reminder output
-
-`RemindersStrategy` is now the only strategy allowed to apply reminders to the prompt.
-
-It owns:
-
-- built-in reminder sources
-- provider full/delta/skip logic
-- reminder placement
-- deferred reminder replay
-- reminder state persistence via the store callback
-
-It returns reminder content in one of three placements:
-
-- `overlay-user`
-- `latest-user-append`
-- `system-append`
-
-### 8. Runtime overlays are appended to prompt history
-
-If context management returned `runtimeOverlays`, TENEX performs a second append-only prompt-history pass:
-
-- `StreamSetup.ts`
-- `StreamCallbacks.ts`
-
-These overlays are added as standalone `runtime-overlay` prompt-history entries.
-
-This is the key safety property:
-
-- old user messages remain unchanged
-- new runtime-only prompt material is stored as new prompt-history entries
-
-### 9. Save only when state changed
-
-TENEX saves the conversation if any of these changed:
-
-- canonical prompt-history entries were appended
-- runtime overlay prompt-history entries were appended
-- reminder engine state changed
-
-## Reminder Placement Model
-
-### `overlay-user`
-
-Used for dynamic reminder content that should remain separate from historical user content.
-
-The library emits a standalone user-role overlay message and TENEX stores it as a runtime overlay in prompt history.
-
-This is the safest placement for volatile state.
-
-### `latest-user-append`
-
-Used when reminder content should be appended to the latest user message in the outgoing prompt only.
-
-This affects the current request but does not rewrite the canonical transcript stored in `ConversationStore`.
-
-TENEX uses this placement only after the host has observed a cache anchor for that agent prompt history.
-
-### `system-append`
-
-Used when reminder content should be emitted as a secondary system message.
-
-TENEX uses this placement while prompt history is still cold, so non-cached providers get the current reminder snapshot in `system` without creating reminder-only `user` turns or replaying stale user-appended reminder history.
-
-## Reminder State Persistence
-
-Reminder engine state is stored in:
-
-- `ConversationState.contextManagementReminderStates`
-
-and accessed via:
-
-- `getContextManagementReminderState(agentPubkey)`
-- `setContextManagementReminderState(agentPubkey, state)`
-- `clearContextManagementReminderState(agentPubkey)`
-
-This state tracks things like:
-
-- prior provider snapshots
-- turns since full reminder emission
-- deferred reminders
-
-It is separate from prompt history because these are different concerns:
-
-- prompt history answers "what did the model see?"
-- reminder state answers "what reminder facts were already conveyed?"
-
-## Prompt History Model
-
-Per-agent prompt history lives in `src/agents/execution/prompt-history.ts`.
-
-Each frozen entry is either:
-
-- `canonical`
-- `runtime-overlay`
-
-Canonical entries come from the conversation projection.
-
-Runtime-overlay entries come from request-time overlays such as system reminders.
-
-This preserves a stable, append-only history of what each agent actually saw without mutating the underlying conversation record.
-
-## Current-Cycle Reminder Queue
-
-The async reminder context in `src/llm/system-reminder-context.ts` is for transient reminders that should not become part of canonical reminder facts.
-
-Examples:
-
-- a supervision correction for this cycle only
-- a deferred one-shot reminder that should appear on the next cycle
-
-Behavior:
-
-- `queue(...)` affects the next `collect()`
-- `defer(...)` affects a future cycle after `advance()`
-- `collect()` drains the queued reminders
-
-These reminders are passed to `RemindersStrategy` as `queuedReminders`, so the placement and overlay logic still stays inside the main reminder strategy.
-
-## Configuration Surface
-
-`src/agents/execution/context-management/settings.ts` currently exposes these strategy toggles:
-
-- `reminders`
-- `toolResultDecay`
-- `compaction`
-- `contextUtilizationReminder`
-- `contextWindowStatus`
-
-Other relevant controls:
-
-- `tokenBudget`
-- `utilizationWarningThresholdPercent`
-- `compactionThresholdPercent`
-
-## What Changed Compared To The Older Design
-
-Older design:
-
-- reminder logic was split between a separate reminder package, TENEX host-side wiring, and prompt-history mutation logic
-- reminder deltas could leak into old transcript messages
-- Anthropic system-prompt behavior was partly treated as a separate reminder concern in the host
-
-Current design:
-
-- reminder orchestration lives in `RemindersStrategy`
-- TENEX supplies facts and reminder providers, not the reminder engine itself
-- prompt history remains append-only
-- runtime overlays remain isolated from canonical transcript history
-
-## Files To Read First
-
-If you need to change this system, start with these files:
-
-- `src/agents/execution/context-management/runtime.ts`
-- `src/agents/execution/request-preparation.ts`
-- `src/agents/execution/prompt-history.ts`
-- `src/agents/execution/system-reminders.ts`
-- `src/llm/system-reminder-context.ts`
-- `src/agents/execution/StreamSetup.ts`
-- `src/agents/execution/StreamCallbacks.ts`
-- `src/conversations/ConversationStore.ts`
-
-Then read the library side:
-
-- `../ai-sdk-context-management/src/strategies/reminders/index.ts`
-- `../ai-sdk-context-management/src/types.ts`
+- The canonical conversation transcript is **immutable**.
+- On each turn, the **`tenex-context`** crate *projects* that history into the
+  `messages[]` the model sees, by running a fixed pipeline of strategies over an
+  in-memory copy. It never mutates stored messages.
+- The system prompt is assembled once (by `tenex-system-prompt`) and stays
+  stable across the turn's steps — it is the cache anchor. Volatile per-turn
+  material (reminders, RAG context) is added to the projected messages, not to
+  the system prompt and not by rewriting historical messages.
+- Projection is **deterministic** from its inputs. There is no asynchronous
+  reminder queue, no provider-specific delta/full/skip logic, and no
+  cache-anchor decision gating — those were TypeScript-era concepts that no
+  longer exist.
+
+## Ownership
+
+- **`tenex-context`** owns projection. Its public surface is `project()` /
+  `project_with_options()` (history → `messages[]`, with token estimates and
+  cache-breakpoint hints) and `record_turn()` (write-back to per-agent prompt
+  history). Modules: `projection`, `tokens`, `turn`, `types`, and `strategies/`.
+- **`tenex-agent`** drives it. The turn loop calls `project_with_options(...)`
+  for each step with a stable system prompt, the precomputed proactive-context
+  block, and the tool definitions; it calls `record_turn(...)` afterward.
+
+## The strategy pipeline
+
+`tenex-context` runs these strategies in a **fixed order** over a clone of the
+projected message list. Each is a pure transformation; none touches the stored
+transcript.
+
+1. **Compaction** — when the projected token count reaches the threshold
+   (default 80% of the model's context window), the system prompt and a recent
+   tail of messages (default 6) are preserved and the middle is collapsed into a
+   summary. The summary is an 8-section LLM-produced digest when a
+   `CompactionSummarizer` is available (`tenex-agent` provides an LLM-backed
+   implementation); otherwise a deterministic placeholder is used.
+2. **Tool-result decay** — the most recent decay-eligible tool results (default
+   3) are kept verbatim; older ones are replaced by a marker that preserves the
+   tool-call/tool-result linkage. Eligibility is per tool via `ToolDef.preserve_results`:
+   tools whose output is a work product (e.g. `load_skill`, `delegate`) are never
+   decayed.
+3. **Delegation-marker expansion** — pending delegations are dropped from the
+   stream and surfaced as an `<agent-delegations>` reminder block on the last
+   non-system message; completed/aborted delegations are rewritten in place as a
+   user message carrying the child transcript; deeply nested delegations are
+   reduced to a one-line reference to bound prompt growth.
+4. **Proactive context (RAG)** — a precomputed RAG block is appended to the last
+   **user** message (computed once per invocation and threaded in as a stable
+   option, so it does not perturb tool-call linkage).
+5. **Reminders** — the current todo state is rendered as a
+   `<system-reminder><agent-todos>` block and appended inline to the last
+   non-system message.
+
+## Reminders, concretely
+
+Reminders are deterministic functions of current state, not a stateful engine.
+They reach the model in two places:
+
+- **In the user message.** At bootstrap, the runner composes the user message
+  from the triggering event plus appended plain-text blocks: the todo reminder,
+  conversation reminders read from the store, and external/remote-agent
+  disclosures. At projection time, the reminders strategy appends the current
+  `<agent-todos>` block to the last non-system message.
+- **In the system prompt (stable additions only).** At bootstrap the runner
+  appends an active-tools reminder and an active-shell-tasks reminder to the
+  otherwise-stable system prompt. Because these are fixed for the duration of the
+  turn, they do not break cache stability.
+
+There is **no** separate runtime-overlay store, no `queue/defer/advance/collect`
+async reminder context, and no per-provider placement model. Supervision
+messages that re-engage an agent are persisted as ordinary `supervision`-type
+user messages in the conversation store (see `docs/SUPERVISION.md`) and then
+projected like any other message — they are not a special reminder channel.
+
+## Prompt history and cache observation
+
+`record_turn()` appends one entry per visible message to the per-agent prompt
+history (`agent_prompt_history`), capturing `agent_pubkey`, `prompt_id`,
+`sequence`, `role`, `source_kind`, and `overlay_type` (e.g. `delegation` for an
+expanded delegation marker). This answers "what did this agent actually see,"
+separately from and without mutating the canonical transcript.
+
+Cache observations from the turn (whether a cache hit occurred, breakpoint hints)
+are recorded for **observability**. They do not gate strategy behavior: reminders
+are always appended to the last message and never rewrite earlier ones, so there
+is no cache-anchor decision logic to maintain.
+
+## Configuration
+
+There is no per-strategy configuration surface. The pipeline order is fixed and
+the thresholds are constants in `tenex-context`: compaction at 80% of context,
+a 6-message preserved tail, 3 verbatim recent tool results. The model's context
+window size is supplied by the runner per request.
+
+## Design intent
+
+- **Immutability + projection.** The transcript is the source of truth; the
+  prompt is a deterministic projection of it. This prevents the prompt-drift
+  failure mode where repeatedly appending reminders into old user messages
+  duplicated content and grew the prompt without bound.
+- **Stable system prompt = reliable caching.** Everything that varies per turn
+  lives in the projected messages (appended to the tail), so the system-prompt
+  cache anchor stays byte-stable. See `docs/system-prompt-architecture.md`.
+- **One pipeline, no hidden lifecycle.** Five composable strategies in a fixed
+  order, each pure, replace the previous runtime's reminder engine, async queue,
+  and overlay bookkeeping.
+
+## Where to look
+
+- `crates/tenex-context/` (`projection.rs`, `strategies/`, `turn.rs`, `types.rs`) and its `AGENTS.md`.
+- `crates/tenex-agent/src/agent_bootstrap/` (user-message composition, system-prompt reminders) and the projection call in `crates/tenex-agent/src/turn_loop/`.
+- `docs/system-prompt-architecture.md` for the stable system-prompt anchor.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,402 +1,174 @@
 # Contributing to TENEX
 
+TENEX is a Rust workspace. The host CLI/supervisor lives in `tenex/`; every other
+concern is a focused crate under `crates/`.
+
 ## Development Workflow
 
 ### Setup
 ```bash
-# Install dependencies
-bun install
+# Build the workspace
+cargo build
 
-# Run tests
-bun test
+# Run the test suite
+cargo test --workspace
 
-# Run type checking
-bun run typecheck
+# Lint (treat warnings seriously)
+cargo clippy --workspace --all-targets
 
-# Run architecture linting
-bun run lint:architecture
+# Format
+cargo fmt --all
 ```
 
 ---
 
 ## Before You Code
 
-### 1. Read the Architecture Guide
-Familiarize yourself with [ARCHITECTURE.md](./ARCHITECTURE.md) to understand:
-- Layered architecture
-- Dependency rules
-- Naming conventions
-- Where to put new code
+### 1. Read the architecture docs
+- **[ARCHITECTURE.md](./ARCHITECTURE.md)** — the crate model, the three roles, and the library-vs-daemon rule.
+- **[crates/AGENTS.md](../crates/AGENTS.md)** — the modularization philosophy and non-negotiable rules.
+- **[MODULE_INVENTORY.md](../MODULE_INVENTORY.md)** — the canonical map of every crate. Find the owning crate before writing code.
+- The `AGENTS.md` inside the specific crate you are changing — it carries that crate's local invariants.
 
-### 2. Check Existing Patterns
-Look for similar code in the codebase and follow established patterns.
+### 2. Check existing patterns
+Look for similar code in the owning crate and follow its established patterns.
 
-### 3. Plan Your Changes
-- What layer does this belong in?
-- Does this create any circular dependencies?
-- Is naming consistent with existing code?
+### 3. Answer the three questions
+1. **Does an existing crate already own this concern?** If yes, extend it.
+2. **Is this a new role in the fleet, or a new instance of an existing role?**
+   New role → new crate. New instance → the existing home for that role.
+3. **Library or daemon?** A process boundary is justified only by concurrency or
+   security isolation, language choice, independent restart, or hot-swap. If
+   undecided, it is a library.
 
 ---
 
 ## Coding Guidelines
 
-### File Organization
+### Where code goes
+- Find the crate that owns the concern (`MODULE_INVENTORY.md`) and put the code there.
+- Keep the three roles separate: **Subscribe** (relay connection), **Orchestrate**
+  (dispatch / RAL / delegation), **Execute** (LLM loop + tools, `tenex-agent`).
+  The runner never opens relays; the orchestrator never calls LLMs.
+- Storage lives behind the owning crate's typed API. SQLite schema changes belong
+  only to the crate that owns the database; JSON layout changes only to the crate
+  that owns that directory.
 
-**Put code in the right layer:**
-- **Pure utilities** → `src/lib/`
-- **TENEX helpers** → `src/utils/`
-- **Business logic** → `src/services/`
-- **Domain logic** → `src/agents/`, `src/conversations/`, `src/tools/`
-- **Entry points** → `src/commands/`, `src/daemon/`, `src/event-handler/`
+### File size
+- Target: under 300 LOC per file.
+- Hard limit: 500 LOC.
+- When a file approaches 300 LOC, split it by responsibility before adding more.
 
-**Create subdirectories** when you have 3+ related files:
-```
-services/
-├── my-feature/
-│   ├── MyFeatureService.ts
-│   ├── types.ts
-│   ├── helper.ts
-│   └── index.ts
-```
+### Naming
+| Thing | Convention | Example |
+|---|---|---|
+| Crates | `tenex-<area>`, kebab-case | `tenex-conversations` |
+| Modules / files | snake_case `.rs` | `store.rs`, `schema.rs` |
+| Types | CamelCase | `ConversationStore` |
+| Functions / fields | snake_case | `list_candidates` |
 
----
-
-### Naming Conventions
-
-**Services:** Use `Service` suffix
-```typescript
-// ✅ Good
-class NotificationService { }
-class EmailService { }
-```
-
-**Files:** Match the class name
-```typescript
-// NotificationService.ts
-export class NotificationService { }
-```
-
-**Utilities:** Use descriptive names
-```typescript
-// nostr-entity-parser.ts
-export function parseNostrEntity() { }
-```
-
----
-
-### Import Patterns
-
-**Use @/ alias for absolute imports:**
-```typescript
-// ✅ Good
-import { config } from "@/services/ConfigService";
-import { formatAnyError } from "@/lib/error-formatter";
-
-// ❌ Bad
-import { config } from "../../../services/ConfigService";
-```
-
-**Import directly from service directories:**
-```typescript
-// ✅ Good
-import { RAGService } from "@/services/rag";
-import { RALRegistry } from "@/services/ral";
-
-// ❌ Bad (avoid barrel imports)
-import { RAGService, RALRegistry } from "@/services";
-```
-
----
-
-### Dependency Management
-
-**Declare dependencies explicitly:**
-```typescript
-export class MyService {
-    constructor(
-        private readonly config: typeof config,
-        private readonly logger: typeof logger
-    ) {}
-}
-
-// Export convenience instance
-export const myService = new MyService(config, logger);
-```
-
-**Check dependency direction:**
-- `lib/` → No TENEX imports
-- `utils/` → Can import `lib/`
-- `services/` → Can import `utils/`, `lib/`, `nostr/`, `llm/`
-- `commands/` → Can import `services/` and below
+### Error handling
+- Represent absence with `Option`; propagate or log-and-bail on failure.
+- Never paper over absent or unresolvable data with sentinel values (`"unknown"`,
+  `String::new()`, `0`). `unwrap_or(None)` on a `Result<Option<T>>` is always
+  wrong — it silently turns I/O and parse errors into "not found".
 
 ---
 
 ## Testing
 
-### Co-locate Tests
-Tests live next to the code they test:
-```
-services/
-├── my-feature/
-│   ├── MyFeatureService.ts
-│   ├── __tests__/
-│   │   └── MyFeatureService.test.ts
-│   └── index.ts
-```
+### Co-locate unit tests
+Unit tests live in a `#[cfg(test)]` module next to the code they test. Integration
+tests live in the crate's `tests/` directory:
 
-### Test Pure Functions
-Pure utilities in `lib/` should be easy to test:
-```typescript
-import { describe, expect, it } from "bun:test";
-import { toKebabCase } from "@/lib/string";
-
-describe("toKebabCase", () => {
-    it("converts PascalCase to kebab-case", () => {
-        expect(toKebabCase("HelloWorld")).toBe("hello-world");
-    });
-});
+```
+crates/tenex-summarizer/
+├── src/
+│   ├── scheduler.rs
+│   └── source.rs
+└── tests/
+    └── discover_and_read.rs
 ```
 
-### Test Services with DI
-Use dependency injection for testability:
-```typescript
-import { describe, expect, it } from "bun:test";
-import { MyService } from "../MyService";
-
-describe("MyService", () => {
-    it("does something", () => {
-        const mockConfig = { get: () => "test-value" };
-        const mockLogger = { info: () => {} };
-        const service = new MyService(mockConfig, mockLogger);
-
-        expect(service.doSomething()).toBe("expected-result");
-    });
-});
+### Run tests
+```bash
+cargo test --workspace          # everything
+cargo test -p tenex-conversations   # one crate
 ```
+
+### End-to-end probes
+For runtime behavior changes, prefer validating with a real end-to-end probe in
+addition to focused unit tests. The runtime probe harness lives under `scripts/`
+(for example `scripts/tenex-runtime-probe.ts`) and drives the actual TENEX
+binaries against the local relay. See the top-level `AGENTS.md` for record/replay
+cassette usage.
 
 ---
 
 ## Commit Guidelines
 
-### Commit Messages
+### Commit messages
 Follow conventional commits:
 ```
-feat: add notification service
-fix: resolve circular dependency in lib/fs
-refactor: simplify worktree metadata handling
+feat(conversations): add delegation-marker synthesis
+fix(summarizer): retry on publish failure
+refactor(context): single source of truth projection
 docs: update architecture guide
-test: add tests for RAG service
+test(scheduler): cover quiet-window candidate selection
 ```
 
-### Pre-Commit Hook
-Our pre-commit hook automatically runs `bun run lint:architecture` to enforce architectural consistency. This check validates:
-- **No Circular Dependencies**: Ensures that our layered architecture is respected.
-- **Layer Boundaries**: Verifies that lower layers do not import from higher layers (e.g., `lib/` cannot import from `services/`).
-- **Naming Conventions**: Checks for consistent service and file naming.
+### Pre-commit hook
+The pre-commit hook runs `cargo check --workspace`. A commit that does not
+compile is blocked. Run `cargo clippy --workspace` and `cargo fmt --all` before
+committing.
 
-**If your commit is blocked:**
-1. **Read the error message carefully.** The architecture linter provides specific feedback on which files and imports are causing the violation.
-2. **Fix the architectural issue.** This usually involves moving code to the correct layer or refactoring to avoid improper dependencies.
-3. **Consult [ARCHITECTURE.md](./ARCHITECTURE.md)** if you are unsure where a piece of code belongs.
-4. If you believe the hook is incorrect, ask for a second opinion in your pull request.
-
----
-
-## Architecture Linting
-
-### Run Manually
-```bash
-bun run lint:architecture
-```
-
-### What It Checks
-- ✅ `lib/` has no imports from `utils/` or `services/`
-- ✅ No circular dependencies
-- ✅ Service naming conventions
-- ✅ Import patterns
-
----
-
-## Common Tasks
-
-### Adding a New Utility
-
-**If it's pure (no TENEX deps):**
-```typescript
-// src/lib/my-util.ts
-export function myUtil(input: string): string {
-    return input.toUpperCase();
-}
-```
-
-**If it's TENEX-specific:**
-```typescript
-// src/utils/my-helper.ts
-import { formatAnyError } from "@/lib/error-formatter";
-
-export function myHelper(agent: AgentInstance): string {
-    // ... TENEX-specific logic
-}
-```
-
----
-
-### Adding a New Service
-
-**1. Create service directory:**
-```bash
-mkdir -p src/services/my-feature
-```
-
-**2. Create service file:**
-```typescript
-// src/services/my-feature/MyFeatureService.ts
-import { config } from "@/services/ConfigService";
-import { logger } from "@/utils/logger";
-
-export class MyFeatureService {
-    constructor(
-        private readonly config: typeof config,
-        private readonly logger: typeof logger
-    ) {}
-
-    doSomething(): void {
-        this.logger.info("Doing something");
-    }
-}
-
-export const myFeatureService = new MyFeatureService(config, logger);
-```
-
-**3. Create types file:**
-```typescript
-// src/services/my-feature/types.ts
-export interface MyFeatureConfig {
-    enabled: boolean;
-}
-```
-
-**4. Create index.ts:**
-```typescript
-// src/services/my-feature/index.ts
-export { MyFeatureService, myFeatureService } from "./MyFeatureService";
-export type { MyFeatureConfig } from "./types";
-```
-
-**5. Use in other code:**
-```typescript
-import { myFeatureService } from "@/services/my-feature";
-
-myFeatureService.doSomething();
-```
-
----
-
-### Adding a New Tool
-
-```typescript
-// src/tools/implementations/my_tool.ts
-import type { ExecutionContext } from "@/agents/execution/types";
-import { tool } from "ai";
-import { z } from "zod";
-
-const myToolSchema = z.object({
-    input: z.string().describe("The input to process"),
-});
-
-async function executeMyTool(
-    input: z.infer<typeof myToolSchema>,
-    context: ExecutionContext
-): Promise<{ result: string }> {
-    // Implementation
-    return { result: "success" };
-}
-
-export const my_tool = tool({
-    description: "Does something useful",
-    parameters: myToolSchema,
-    execute: async (input, { context }) => {
-        return await executeMyTool(input, context);
-    },
-});
-```
+### Multi-agent working tree
+This project runs multiple agents concurrently:
+- **Never stash, reset, or revert uncommitted changes** — another agent or the
+  user may have in-progress work.
+- **Never assume the working tree is clean.** Baseline your diff with
+  `git diff HEAD` before you start, and compare afterward to isolate your changes.
+- **Commit only your own changes.** Do not commit files you did not touch.
 
 ---
 
 ## The Boy Scout Rule
 
-**Always leave the code better than you found it.**
-
-When working in a file, take the opportunity to make small improvements:
-- Fix typos or unclear comments.
-- Improve variable names for clarity.
-- Move misplaced functions to their correct architectural layer.
-- Update imports to use the `@/` alias.
-- Resolve any nearby TODOs if they are trivial.
-
-These small, incremental improvements are crucial for maintaining the long-term health and quality of the codebase. Every contribution, no matter how small, is an opportunity to improve our collective environment.
+Leave every file better than you found it. When you touch a file, fix the obvious
+nearby thing — a stale comment, a misplaced `use`, an off-pattern name. Don't
+widen scope into a refactor PR, but don't walk past rot either.
 
 ---
 
-## Getting Help
+## Breaking Changes
 
-### Architecture Questions
-1. Check [ARCHITECTURE.md](./ARCHITECTURE.md) first
-2. Search for similar code in the codebase
-3. Ask in PR review
-4. Consult with team
+This project is in active development. We prioritize code quality, architectural
+integrity, and coherence over backward compatibility.
 
-### Blocked by Pre-Commit Hook?
-The hook uses Claude Code to review commits. If blocked:
-1. Read the feedback carefully
-2. Fix the architectural issue
-3. Check if you're introducing circular dependencies
-4. Verify you're adding code to the right layer
-
-**The hook is strict but helpful** - it prevents technical debt.
+- **Do not hesitate to refactor** if it improves the codebase.
+- **No compatibility shims past a single bounded cutover.** Rename and update all
+  call sites; don't re-export old names.
+- **Update all relevant documentation** in the same pull request — including the
+  affected crate's `AGENTS.md`, `MODULE_INVENTORY.md`, and the architecture map
+  when you add, split, or merge a crate.
 
 ---
 
 ## Pull Request Checklist
 
 Before submitting:
-- [ ] Tests pass: `bun test`
-- [ ] Types check: `bun run typecheck`
-- [ ] Architecture lint passes: `bun run lint:architecture`
-- [ ] Pre-commit hook passes (commit locally first)
-- [ ] Code follows naming conventions
-- [ ] No circular dependencies introduced
-- [ ] Code is in the correct layer
-- [ ] Documentation updated if needed
+- [ ] Builds: `cargo build --workspace`
+- [ ] Tests pass: `cargo test --workspace`
+- [ ] Clippy is clean: `cargo clippy --workspace --all-targets`
+- [ ] Formatted: `cargo fmt --all`
+- [ ] Code lives in the crate that owns the concern
+- [ ] The three roles stay separate
+- [ ] Documentation updated (crate `AGENTS.md` / `MODULE_INVENTORY.md` if structure changed)
 
 ---
 
-## Advanced Topics
+## Getting Help
 
-### Refactoring Services
-When refactoring legacy code:
-1. Don't change everything at once
-2. Rename files first (update imports)
-3. Rename classes in separate PR
-4. Add DI gradually
-5. Group into subdirectories when beneficial
-
-### Breaking Changes
-As this project is in active development and pre-release, we do not guarantee backward compatibility. We prioritize code quality, architectural integrity, and innovation over maintaining legacy interfaces.
-
-**Guidelines for making breaking changes:**
-- **Do not hesitate to refactor** if it improves the codebase.
-- **Update all relevant documentation** in the same pull request.
-- **Communicate significant changes** to the team to ensure everyone is aligned.
-
----
-
-## Questions?
-
-If you're unsure about anything:
-- Check [ARCHITECTURE.md](./ARCHITECTURE.md)
-- Look for similar patterns in the codebase
-- Ask in PR review
-- Trust the pre-commit hook feedback
-
-**When in doubt, ask!**
+1. Check [ARCHITECTURE.md](./ARCHITECTURE.md) and the owning crate's `AGENTS.md`.
+2. Search for similar code in that crate.
+3. Ask in PR review.

--- a/docs/CONVERSATION-ID-ARCHITECTURE.md
+++ b/docs/CONVERSATION-ID-ARCHITECTURE.md
@@ -2,132 +2,76 @@
 
 ## Overview
 
-Conversation IDs exist in two forms:
-1. **Canonical IDs** (64-char hex) - used internally for lookups, matching, storage
-2. **Display IDs** (10-char shortened) - used in tool output, logs, UI
+A conversation ID is a **full 64-character hex Nostr event id** — the id of the
+event that rooted the conversation. TENEX does not mint conversation ids; they
+come from Nostr. They are stored and matched canonically, in full.
 
-## Architecture Layers
+Conversation ids appear in two forms:
 
-### Data Layer: `ConversationCatalogService`
+1. **Canonical IDs** (full 64-char hex) — used for all storage, lookup, and
+   matching.
+2. **Display IDs** (a short prefix) — used only when rendering to humans in tool
+   output and logs.
 
-**Returns:** Full canonical IDs (64-char hex)
+The distinction is a **presentation concern, not a storage concern**. The data
+layer always works with full ids; shortening happens at the point of display.
 
-**Used by:**
-- Internal systems (migrations, reminders, indexing)
-- Code that needs to match/lookup conversations
-- Systems that aggregate across conversations
+## Storage: a single `ConversationStore`
 
-**Why full IDs:** The catalog is a shared programmatic read model used for internal logic that requires exact ID matching. Returning shortened IDs breaks migrations, deduplication, and cross-reference logic.
+All conversation state for a project lives in one SQLite database,
+`~/.tenex/projects/<dTag>/conversation.db`, owned by the **`tenex-conversations`**
+crate. Every consumer — the project runtime, the agent runner, the summarizer,
+the intervention watcher, conversation tools — opens that same file through
+`ConversationStore`. There is no separate "catalog" database and no read-model
+service in front of the store: read methods on `ConversationStore` serve all
+consumers directly.
 
-```typescript
-const catalog = ConversationCatalogService.getInstance(projectId);
-const conversations = catalog.listConversations({ limit: 50 });
-// conversations[0].id === "abc123...xyz" (64 chars)
-```
+The `conversations.id` column is the full hex id (a `TEXT PRIMARY KEY`). The
+store never truncates ids. Returning a shortened id from a read method would
+break matching, deduplication, delegation-chain reconstruction, and migration.
 
-### Presentation Layer: `ConversationPresenter`
+> Historical note: the previous TypeScript runtime split this into a canonical
+> `ConversationStore` plus a derived `ConversationCatalogService` over a separate
+> `conversation-catalog.db`, with a `ConversationPresenter` formatting layer.
+> Those types do not exist in the Rust system; the four-store TypeScript layout
+> was consolidated into the single `conversation.db` by a one-time migration
+> (`tenex-conversations`'s `migration` module).
 
-**Returns:** Shortened display IDs + full IDs for lookups
+## Display: shortening at the edge
 
-**Used by:**
-- Tools that display data to users
-- Code that uses the catalog and needs formatted output
+Shortening is applied by each consumer when it renders ids for humans, never by
+the store. The conventions in the current code:
 
-```typescript
-import { ConversationPresenter } from "@/conversations/presenters/ConversationPresenter";
+- The **host CLI** (`tenex` binary) has a shared `shorten_event_id` helper
+  (`tenex/src/utils/identifiers.rs`) that takes a 10-character prefix of a hex
+  event id. Telegram-style ids (prefixed `tg_`) are hashed before truncation so
+  they stay opaque and fixed-length.
+- The **`conversation_get`** agent tool shortens to a 10-character prefix and
+  resolves collisions when several ids share a prefix in the same view.
+- The **`conversation_list`** agent tool shortens to an 8-character prefix for
+  its line-formatted output.
+- The **`conversation_search`** tool returns full ids to its caller; it does not
+  shorten.
 
-const catalog = ConversationCatalogService.getInstance(projectId);
-const entries = catalog.listConversations({ limit: 50 });
-const formatted = ConversationPresenter.formatListEntries(entries);
-// formatted[0].id === "abc123..." (10 chars, shortened)
-// formatted[0].fullId === "abc123...xyz" (64 chars, for lookups)
-```
+There is intentionally **no single library-level `shorten_conversation_id`
+function**: a conversation id *is* a Nostr event id, so display shortening is the
+same operation as event-id shortening, and it lives with the consumer that owns
+the rendering (the host binary's helper, or the tool's own formatter).
 
-### Tool Layer
+## Rules
 
-**Option A: Simple tools using catalog**
-- Use `ConversationCatalogService` + `ConversationPresenter`
-- Get automatic ID formatting
-- No manual shortening needed
+1. **Never shorten at the storage layer.** `ConversationStore` returns full
+   canonical ids. Shorten only when producing human-facing output.
+2. **Treat a conversation id as a Nostr event id.** Reuse the host's
+   `shorten_event_id` helper rather than re-implementing truncation, so special
+   cases (e.g. Telegram ids) stay consistent.
+3. **Keep the full id reachable.** A view that displays a short id must retain
+   the full id for any subsequent lookup.
+4. **Document deliberate prefix lengths.** Tools that pick a non-standard prefix
+   length (e.g. `conversation_list`'s 8 chars) should say why.
 
-**Option B: Complex tools with special needs**
-- May load directly from `ConversationStore` (e.g., for delegation chain metadata)
-- Use centralized `shortenConversationId()` helper for formatting
-- Example: `conversation_list` (builds tree structures from delegation chains)
+## Related
 
-```typescript
-import { shortenConversationId } from "@/utils/conversation-id";
-
-// For custom tree structures or special metadata
-const store = ConversationStore.getOrLoad(fullId);
-const displayId = shortenConversationId(store.id);
-```
-
-## When to Use Which
-
-| Use Case | Data Source | ID Formatting |
-|----------|------------|---------------|
-| Internal matching/lookups | `ConversationCatalogService` | Use full IDs as-is |
-| Tool displaying lists | `ConversationCatalogService` + `ConversationPresenter` | Automatic shortened IDs |
-| Custom tree structures | `ConversationStore` directly | Manual with `shortenConversationId()` |
-| Migrations/indexing | `ConversationCatalogService` | Full IDs (no formatting) |
-| Logging/traces | Any source | `shortenConversationId()` helper |
-
-## Critical Rules
-
-1. **Never shorten IDs at the data layer** - The catalog must return full canonical IDs for internal system integrity
-
-2. **Use the centralized helper** - Always use `shortenConversationId()` from `@/utils/conversation-id`, never substring or duplicate logic
-
-3. **Keep full IDs available** - The presenter includes both shortened (`id`) and full (`fullId`) for lookups
-
-4. **Document special cases** - Tools with custom needs (like tree structures) should document why they bypass the presenter
-
-## Examples
-
-### ✅ Correct: Simple tool with catalog
-
-```typescript
-const catalog = ConversationCatalogService.getInstance(projectId);
-const entries = catalog.listConversations({ limit: 50 });
-const formatted = ConversationPresenter.formatListEntries(entries);
-return { conversations: formatted }; // Shortened IDs automatically
-```
-
-### ✅ Correct: Complex tool with special needs
-
-```typescript
-// conversation_list tool - needs delegation chain tree structure
-const conversations = loadConversationsFromStore();
-return conversations.map(conv => ({
-    id: shortenConversationId(conv.id), // Use centralized helper
-    children: buildTreeStructure(conv), // Custom logic
-}));
-```
-
-### ❌ Wrong: Shortening at data layer
-
-```typescript
-// DON'T DO THIS in ConversationCatalogService
-private toPreview(row: ConversationRow): ConversationCatalogPreview {
-    return {
-        id: shortenConversationId(row.conversation_id), // ❌ Breaks migrations!
-        // ...
-    };
-}
-```
-
-### ❌ Wrong: Manual shortening without helper
-
-```typescript
-// DON'T DO THIS
-const displayId = fullId.substring(0, 10); // ❌ Duplicates logic, breaks special IDs
-```
-
-## Testing
-
-When testing catalog-dependent code:
-- Verify full 64-char IDs are returned from catalog methods
-- Test that migrations/reminders work with full IDs
-- Test that presenter correctly shortens IDs while preserving fullId
-- Test that tools using the helper get consistent formatting
+- `crates/tenex-conversations/AGENTS.md` — store invariants and the single-file contract.
+- `docs/internals/conversation-metadata-generation.md` — how metadata is generated for conversations.
+- `docs/CONVERSATION_INDEXING.md` — conversation indexing for RAG.

--- a/docs/CONVERSATION_INDEXING.md
+++ b/docs/CONVERSATION_INDEXING.md
@@ -1,190 +1,94 @@
 # Conversation Indexing
 
-TENEX automatically indexes conversations for semantic search using RAG (Retrieval-Augmented Generation).
+TENEX embeds conversation transcripts so they are searchable by semantic
+similarity (RAG). Indexing is performed by a standalone daemon, **`tenex-embedder`**,
+backed by the **`tenex-rag`** storage layer.
 
 ## How It Works
 
-- **Automatic Background Indexing**: Runs every 5 minutes when the daemon is active
-- **Smart Change Detection**: Only re-indexes conversations when content changes
-- **Full Transcript Indexing**: Embeds complete conversation history (not just metadata)
-- **Project Isolation**: Properly scopes search results to project boundaries
+- **Source of truth is Nostr.** The embedder reads kind:1 events from the
+  configured relays, filtered to the projects owned by the host (derived from
+  `tenexPrivateKey` plus the project `event.json` files). It does **not** read
+  the local `conversation.db`.
+- **Standalone daemon, not an in-runtime job.** `tenex-embedder` runs as a host
+  companion process and scans on a short interval (every 30 seconds), walking
+  bounded windows of relay history from a persisted cursor.
+- **Change detection.** Per conversation it tracks the event count and the
+  newest `created_at`; an unchanged conversation is skipped. When a conversation
+  has advanced, its transcript is re-chunked and only chunks whose content hash
+  changed are re-embedded.
+- **Full transcript.** It embeds the conversation transcript, not just metadata.
+- **Project scoping.** Chunks are tagged with their project id(s) so search can
+  filter to a project.
 
-## CLI Commands
+## Storage
 
-### Check Indexing Status
+- Embeddings live in a global SQLite store at `~/.tenex/embeddings.db`
+  (vector-enabled), owned by `tenex-rag`.
+- The embedder keeps its own bookkeeping under `~/.tenex/.embedder/`: per-
+  conversation state (`state.db`) and the relay-walk cursor (`cursor.db`).
 
-```bash
-tenex doctor conversations status
-```
+## Chunking
 
-Displays:
-- Total indexed conversations
-- RAG collection stats
-- Indexing job status
-- Embedding provider info
-- Number of tracked conversations
+Transcripts are chunked with message-aligned windows: a target size around
+6,000 characters (~1,500 tokens for `text-embedding-3-small`), a hard ceiling
+above which a single message is truncated, and a few trailing messages of
+overlap carried into the next chunk for continuity. Each chunk carries a SHA-256
+content hash used for change detection, plus metadata (conversation id, project
+id(s), chunk index, sequence range, timestamps).
 
-**Example Output:**
-```
-Checking conversation indexing status...
+## CLI
 
-RAG Collection:
-  Collection: conversation_embeddings
-  Total indexed: 42
-  Has content: yes
-  Embedding provider: OpenAI text-embedding-3-small
-
-Indexing Job:
-  Running: yes
-  Batch in progress: no
-  Interval: 5 minutes
-
-Indexing State:
-  Tracked conversations: 42
-
-✓ Conversation indexing is active
-```
-
-### Force Full Re-index
+The daemon handles indexing automatically. For manual operations:
 
 ```bash
-tenex doctor conversations reindex
+# One-shot backfill of a single project's conversations from the relays
+tenex doctor conversations backfill <project> [--since <unix-secs>]
+
+# The embedder's own backfill (bulk pass), with reset / window / dry-run
+tenex-embedder backfill [--since <unix-secs>] [--reset] [--dry-run]
 ```
 
-This will:
-1. Clear all indexing state
-2. Re-index all conversations across all projects
-3. Re-embed conversations even if they haven't changed
+`--reset` re-embeds even unchanged chunks (use it after changing the embedding
+provider or model). `tenex doctor conversations status` and `… reindex` exist as
+diagnostics but are limited; the backfill commands above are the wired path.
 
-**With Confirmation Skip:**
-```bash
-tenex doctor conversations reindex --confirm
-```
+Configure the embedding provider/model with:
 
-Use this when:
-- You've changed embedding providers
-- You've updated the embedding model
-- Conversations aren't appearing in search results
-- You suspect indexing corruption
-
-## Automatic Indexing
-
-The `ConversationIndexingJob` runs automatically in the background when the daemon is active:
-
-- **Frequency**: Every 5 minutes
-- **Detection**: Uses content versioning + metadata hashing
-- **Efficiency**: Only indexes new/changed conversations
-- **State Tracking**: Durable per-conversation state in catalog
-
-### What Triggers Re-indexing?
-
-A conversation is re-indexed when:
-1. **Content version changes** (e.g., v1 → v2 format upgrade)
-2. **Metadata changes**: title, summary, lastUserMessage, or lastActivity
-3. **Never indexed before**
-
-### What Doesn't Trigger Re-indexing?
-
-- Unchanged conversations (skip redundant work)
-- Conversations marked as "no content" (empty conversations)
-
-## Search Tools
-
-Once indexed, conversations are searchable via:
-
-1. **`conversation_search` tool** (agents)
-   - Keyword mode (fast title matching)
-   - Semantic mode (natural language)
-   - Hybrid mode (both)
-   - Full-text mode (deep message search)
-
-2. **`rag_search` tool** (agents)
-   - Unified search across all RAG collections
-   - Includes conversations + lessons + custom collections
-   - Optional LLM-based extraction
-
-## Architecture
-
-```
-ConversationIndexingJob (5min cron)
-  ↓
-IndexingStateManager (tracks what needs indexing)
-  ↓
-ConversationEmbeddingService (builds documents)
-  ↓
-RAGService (stores in vector DB)
-  ↓
-Vector Store (SQLite-vec/Qdrant)
-```
-
-### Key Files
-
-- `src/conversations/search/embeddings/ConversationIndexingJob.ts` - Background indexer
-- `src/conversations/search/embeddings/ConversationEmbeddingService.ts` - Document builder
-- `src/conversations/search/embeddings/IndexingStateManager.ts` - State tracker
-- `src/tools/implementations/conversation_search.ts` - Search tool
-- `src/tools/implementations/rag_search.ts` - Unified RAG search
-
-## Troubleshooting
-
-### No conversations showing in search
-
-1. Check indexing status:
-   ```bash
-   tenex doctor conversations status
-   ```
-
-2. If `Total indexed: 0`, run reindex:
-   ```bash
-   tenex doctor conversations reindex
-   ```
-
-3. Verify daemon is running:
-   ```bash
-   tenex daemon-status
-   ```
-
-### Search results are stale
-
-The indexing job runs every 5 minutes. Recent conversations will be indexed automatically.
-
-To force immediate indexing:
-```bash
-tenex doctor conversations reindex --confirm
-```
-
-### Embedding provider errors
-
-Check your LLM provider configuration:
-```bash
-tenex config providers
-```
-
-Ensure you have:
-- Valid API keys
-- Correct embedding model configured
-- Network connectivity to provider
-
-### Memory issues during indexing
-
-Indexing embeds full conversation transcripts. For large histories:
-- Indexing happens sequentially to limit memory usage
-- Each batch is 20 conversations (configurable in code)
-- Progress is saved incrementally (failures don't lose progress)
-
-## Configuration
-
-Embedding settings are configured via:
 ```bash
 tenex config embed
 ```
 
-Supported providers:
-- OpenAI (text-embedding-3-small, text-embedding-3-large)
-- Anthropic (Voyage AI models)
-- OpenRouter (various models)
-- Local providers (via MCP)
+## Search Tools (agents)
 
-Vector store configuration is read from the `vectorStore` field in `embed.json`:
-- `provider`: `sqlite-vec` (default) or `qdrant`
-- `url`: Qdrant server URL (if using Qdrant)
+- **`conversation_search`** — semantic search over the shared `conversations`
+  collection. Defaults to the current project; pass `project_id: "ALL"` to search
+  across all projects. Returns score, content, title, conversation id, and
+  project id.
+- **`rag_search`** — unified semantic search across the `conversations`
+  collection, the project knowledge base (`project_<id>`), and the agent's own
+  notes (`agent_<pubkey>`). If a `prompt` is supplied, it additionally runs an
+  LLM pass to extract a focused answer from the matches.
+- **`rag_add_documents`** — adds documents by audience scope: `self` →
+  `agent_<pubkey>`, `project` → `project_<id>`. Agents add documents by scope;
+  they do not create, list, or delete collections.
+
+## Troubleshooting
+
+**Nothing appears in search.** Confirm the `tenex-embedder` daemon is running and
+that the relays hold the conversation events (the embedder reads from relays, not
+local disk). Run a backfill for the project:
+`tenex doctor conversations backfill <project>`.
+
+**Results look stale after changing models.** Re-embed everything with
+`tenex-embedder backfill --reset`.
+
+**Embedding provider errors.** Check the provider configuration and API keys via
+`tenex config embed` / `tenex config providers`, and confirm network access to
+the provider.
+
+## Where to look
+
+- `crates/tenex-embedder/` (`scope.rs`, `backfill.rs`, `cursor.rs`, `processor.rs`, `chunking.rs`, `state.rs`, `scheduler.rs`, `tuning.rs`; `lib.rs` documents the relay-source design).
+- `crates/tenex-rag/` (`sqlite_store.rs`, `store.rs`, `rag.rs`).
+- `crates/tenex-agent/src/tools/conversation_search.rs`, `rag_search.rs`, `rag_add_documents.rs`.

--- a/docs/DELEGATION-AND-RAL-PROCESSING.md
+++ b/docs/DELEGATION-AND-RAL-PROCESSING.md
@@ -1,6 +1,17 @@
 # Delegation and RAL Processing
 
-This document describes how delegation and RAL (Reason-Act Loop) state is tracked and resumed in the current implementation.
+> **Historical reference.** This document describes the delegation/RAL
+> (Reason-Act Loop) machinery of the **now-removed TypeScript runtime**
+> (`src/services/ral/RALRegistry.ts`, `src/agents/execution/*.ts`, the
+> `StopExecutionSignal` flow). The Rust runtime does not replicate this
+> in-memory RAL model. It is kept as a record of the prior design.
+>
+> For current Rust behavior, see `docs/internals/ral-lifecycle-and-mid-run-injection.md`
+> and `docs/internals/delegation-followup-runtime.md`. The shared **wire
+> contract** below (event kinds and tags) is still accurate, since the Rust
+> runtime preserves it.
+
+This document describes how delegation and RAL state was tracked and resumed in the TypeScript runtime.
 
 ## Key Components
 

--- a/docs/RUST-AGENT-SPEC.md
+++ b/docs/RUST-AGENT-SPEC.md
@@ -317,7 +317,7 @@ Search file contents using ripgrep (falls back to grep). Pattern is always treat
 | `description` | string | Brief reason for this search |
 | `path` | string? | File or directory to search (defaults to cwd) |
 | `output_mode` | string? | `files_with_matches` \| `content` \| `count` (default: `files_with_matches`) |
-| `glob` | string? | Glob filter for files (e.g. `*.ts`) |
+| `glob` | string? | Glob filter for files (e.g. `*.rs`) |
 | `-i` | bool? | Case-insensitive search |
 | `-A` | integer? | Lines of trailing context (content mode) |
 | `-B` | integer? | Lines of leading context (content mode) |
@@ -512,7 +512,7 @@ Request a silent completion for the current turn. Use only when the user's messa
 
 No parameters.
 
-Uses `Arc<AtomicBool>::swap(true)` — idempotent: a second call detects the flag was already set and returns a "STOP — do not call this tool again" advisory instead of silently no-op'ing. After the inner rig loop ends, `main.rs` checks the flag before emitting the final `ConversationIntent` — if set, no event is published and the turn ends silently. Note: the TS implementation (in `no_response.ts`) uses a similar early-exit pattern; the Rust version is behaviorally equivalent.
+Uses `Arc<AtomicBool>::swap(true)` — idempotent: a second call detects the flag was already set and returns a "STOP — do not call this tool again" advisory instead of silently no-op'ing. After the inner rig loop ends, `main.rs` checks the flag before emitting the final `ConversationIntent` — if set, no event is published and the turn ends silently.
 
 ### `report_publish`
 Publish markdown files as NIP-23 long-form articles (kind:30023) to Nostr, signed with the agent's keys. Accepts a single file or a directory (directory walk is recursive). Path may be absolute or relative to the project root.

--- a/docs/SUPERVISION.md
+++ b/docs/SUPERVISION.md
@@ -1,395 +1,147 @@
 # TENEX Supervision Internals
 
-This document explains how TENEX supervises agent executions, with emphasis on post-completion heuristics, re-engagement, repeatable gates, and the structured-state exits that let an agent stop safely.
-
-It is intended for contributors changing any of:
-
-- `src/agents/supervision/*`
-- `src/agents/execution/PostCompletionChecker.ts`
-- `src/agents/execution/AgentExecutor.ts`
-- `src/tools/implementations/ask.ts`
-- `src/tools/implementations/todo.ts`
-- `src/services/ral/*`
-
-## Scope
-
-TENEX supervision is the runtime layer that checks whether an agent's behavior should be corrected before:
-
-- a completion is published
-- a tool is allowed to run
-
-The current default configuration only registers post-completion heuristics, but the subsystem supports both:
-
-- `post-completion`
-- `pre-tool-execution`
-
-## Design Goals
-
-The supervision system exists to enforce a few different kinds of rules:
-
-1. Objective state checks.
-2. Higher-level behavioral checks that may need LLM verification.
-3. Low-stakes nudges that should not block progress.
-
-The important design distinction is:
-
-- Some heuristics are advisory and should only fire once.
-- Some heuristics are gates and must keep firing until the underlying condition changes.
-
-This distinction is now explicit in code through `HeuristicEnforcementMode`.
-
-## Main Components
-
-| File | Responsibility |
-| --- | --- |
-| `src/agents/supervision/registerHeuristics.ts` | Registers the default heuristics once during startup |
-| `src/agents/supervision/heuristics/HeuristicRegistry.ts` | Stores heuristics and filters by timing |
-| `src/agents/supervision/SupervisorOrchestrator.ts` | Runs detections, optional LLM verification, and returns correction actions |
-| `src/agents/supervision/SupervisorLLMService.ts` | Verifies non-objective detections with the supervision model |
-| `src/agents/supervision/types.ts` | Defines contexts, correction actions, enforcement modes, and retry limits |
-| `src/agents/execution/PostCompletionChecker.ts` | Builds post-completion context, invokes supervision, and re-engages the agent |
-| `src/agents/execution/AgentExecutor.ts` | Calls the checker before final publish and decides whether the turn can finish |
-| `src/llm/system-reminder-context.ts` | Queues ephemeral supervision reminders for the next request |
-| `src/tools/implementations/ask.ts` | Creates `PendingDelegation` state, which is a structured way to stop with unresolved work |
-| `src/tools/implementations/todo.ts` | Defines the conversation-scoped todo state machine, including `skipped` plus `skip_reason` |
-
-## Startup and Fail-Closed Registration
-
-Default supervision is registered in `ProjectRuntime` through `registerDefaultHeuristics()`.
-
-Current default heuristics:
-
-- `silent-agent`
-- `delegation-claim`
-- `consecutive-tools-without-todo`
-- `pending-todos`
-
-`SupervisorOrchestrator.checkPostCompletion()` runs a health check before evaluating anything. If no post-completion heuristics are registered, it throws. This is intentional fail-closed behavior so supervision cannot silently disappear due to startup drift.
-
-## Current Default Heuristics
-
-### `silent-agent`
-
-File: `src/agents/supervision/heuristics/SilentAgentHeuristic.ts`
-
-Purpose:
-
-- blocks empty or error-fallback completions unless silent completion was explicitly requested
-
-Behavior:
-
-- requires LLM verification
-- uses `suppress-publish` with `reEngage: true`
-- enforcement mode: `repeat-until-resolved`
-
-### `delegation-claim`
-
-File: `src/agents/supervision/heuristics/DelegationClaimHeuristic.ts`
-
-Purpose:
-
-- blocks "I delegated" style claims when no delegate tool was actually called
-
-Behavior:
-
-- requires LLM verification
-- uses `suppress-publish` with `reEngage: true`
-- enforcement mode: `repeat-until-resolved`
-
-### `pending-todos`
-
-File: `src/agents/supervision/heuristics/PendingTodosHeuristic.ts`
-
-Purpose:
-
-- blocks completion while the agent still has `pending` or `in_progress` todo items
-
-Behavior:
-
-- objective check, so `skipVerification = true`
-- uses `suppress-publish` with `reEngage: true`
-- enforcement mode: `repeat-until-resolved`
-- intentionally suppresses itself when `pendingDelegationCount > 0`
-
-The suppression condition is important. TENEX treats "waiting on delegated work or a human answer" as a valid structured reason to stop even if todos remain incomplete.
-
-### `consecutive-tools-without-todo`
-
-File: `src/agents/supervision/heuristics/ConsecutiveToolsWithoutTodoHeuristic.ts`
-
-Purpose:
-
-- nudges the agent to start using `todo_write()` after many tool calls without a todo list
-
-Behavior:
-
-- objective check, so `skipVerification = true`
-- uses `inject-message` with `reEngage: false`
-- default enforcement mode: `once-per-execution`
-- also suppresses itself once the conversation has been marked as already nudged
-
-This is intentionally not a gate.
-
-## Enforcement Modes
-
-Defined in `src/agents/supervision/types.ts`:
-
-- `once-per-execution`
-- `repeat-until-resolved`
-
-These modes control what "already enforced" means.
-
-### `once-per-execution`
-
-Interpretation:
-
-- the system assumes that delivering the warning once is sufficient
-
-Effect:
-
-- `SupervisorOrchestrator` skips the heuristic on later checks for the same execution once it has been marked enforced
-
-Use this for:
-
-- advisory nudges
-- corrections where repeated firing would mostly create noise
-
-### `repeat-until-resolved`
-
-Interpretation:
-
-- the condition itself must change before completion can pass
-
-Effect:
-
-- the heuristic is re-evaluated on every completion attempt within the same execution
-- prior enforcement does not disable future checks
-
-Use this for:
-
-- objective completion gates
-- conditions where "warning delivered" is not the same as "problem resolved"
-
-## What "Execution" Means Here
-
-The supervision state is keyed by:
-
-```ts
-`${agent.pubkey}:${conversationId}:${ralNumber}`
-```
-
-This identifier is built in `PostCompletionChecker.ts` and is effectively RAL-scoped. The name `executionId` is historical; in practice it means "this agent in this conversation in this RAL."
-
-Supervision state currently tracks:
-
-- `retryCount`
-- `maxRetries`
-- `lastHeuristicTriggered`
-- `enforcedHeuristics`
-
-This state is stored in memory in `SupervisorOrchestrator`.
-
-Implementation note:
-
-- there is a `clearState()` helper, but production code does not currently call it
-- in practice this has not been used as the main lifecycle boundary because execution IDs are RAL-scoped and monotonically change as new RALs are created
-
-If future work depends on stronger cleanup guarantees, revisit this lifecycle explicitly rather than assuming the current map is self-pruning.
-
-## Post-Completion Flow
-
-### 1. AgentExecutor reaches completion
-
-`AgentExecutor` receives a completion event from the model and calls `checkPostCompletion(...)` before publishing anything.
-
-### 2. PostCompletionChecker builds `PostCompletionContext`
-
-`PostCompletionChecker` collects:
-
-- final message content
-- output token count
-- tool calls made during this RAL
-- conversation history
-- available tools
-- todo list state
-- silent-completion request state
-- conversation-wide pending delegation count
-- whether the completion used the error fallback
-
-The conversation-wide pending delegation count is intentionally not RAL-scoped:
-
-- `pending-todos` should stay suppressed if the agent is still waiting on work from an earlier RAL in the same conversation
-
-### 3. SupervisorOrchestrator evaluates heuristics
-
-For each applicable heuristic:
-
-1. skip it only if it is already enforced and its mode is `once-per-execution`
-2. run `detect(...)`
-3. if `skipVerification` is set, synthesize a violation directly
-4. otherwise call `SupervisorLLMService.verify(...)`
-5. build the correction action
-
-Possible correction action types:
-
-- `inject-message`
-- `block-tool`
-- `suppress-publish`
-
-Current default post-completion heuristics use:
-
-- `inject-message`
-- `suppress-publish`
-
-### 4. PostCompletionChecker applies the correction
-
-If the result is `inject-message`:
-
-- it queues a `supervision-message`
-- the current completion is allowed to finish
-- the message appears on a later request
-
-If the result is `suppress-publish` plus `reEngage: true`:
-
-- it queues a `supervision-correction`
-- it returns `shouldReEngage: true`
-- `AgentExecutor` immediately runs the agent again instead of publishing
-
-The reminder queue is described in `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md`. Supervision uses that queue so corrections affect the model-facing prompt without mutating the canonical transcript.
-
-### 5. AgentExecutor makes the final publish decision
-
-If supervision does not re-engage the agent, `AgentExecutor` still re-checks `RALRegistry.hasOutstandingWork(...)` before deciding whether to publish:
-
-- a final completion
-- or an ordinary conversation message
-
-This is separate from supervision. Supervision enforces behavior rules. `hasOutstandingWork(...)` enforces runtime execution state such as queued injections and delegation completion handling.
-
-## Repeatable Gates and Final Corrections
-
-`MAX_SUPERVISION_RETRIES` is currently `3`.
-
-Old behavior:
-
-- a re-engaging heuristic could be marked enforced once
-- later completion attempts in the same execution could pass simply because the heuristic had already fired once
-- after enough retries, the system could fall through to "publish anyway"
-
-Current behavior for `repeat-until-resolved` heuristics:
-
-- the heuristic is re-checked on every completion attempt
-- reaching the retry limit does not allow publish-through
-- on the last allowed retry, TENEX injects a stronger final correction
-- after the limit is reached, TENEX keeps blocking and keeps the gate active
-
-The final correction is intentionally directive. It tells the agent that the turn still cannot complete and that it must resolve the issue in structured state.
-
-## Structured Resolution Paths
-
-The supervision design deliberately prefers structured state changes over free-text excuses.
-
-### Continue the work
-
-If the agent is genuinely not finished, it should keep working and update its todo list as progress changes.
-
-### Use `ask()`
-
-If the agent cannot continue without human input or external confirmation, it should call `ask()`.
-
-Why this matters:
-
-- `ask()` immediately registers a `PendingDelegation` of type `ask`
-- `pending-todos` sees the resulting `pendingDelegationCount > 0`
-- the todo gate is then suppressed because the agent is now waiting on a structured external dependency
-
-### Mark items `skipped`
-
-If a todo item is no longer relevant, the agent should call `todo_write` and mark it:
-
-- `status: "skipped"`
-- `skip_reason: "..."`
-
-This is the structured way to say "I intentionally did not do this item."
-
-### What TENEX does not currently use
-
-TENEX does not currently use a separate `blocked` todo status for supervision. The current structured exits are:
-
-- `done`
-- `skipped` with `skip_reason`
-- pending delegation state such as `ask()`
-
-## Why `pending-todos` Is Repeatable
-
-This heuristic is the clearest example of why enforcement mode matters.
-
-The relevant distinction is:
-
-- "the warning was delivered"
-- "the todo state changed"
-
-Those are not equivalent.
-
-If an agent is told "you still have pending todos" and then responds with another completion attempt that leaves the same todo state intact, the gate must fire again. The system should not infer that the agent had a valid reason just because it received the first warning.
-
-For `pending-todos`, the condition is considered resolved only when one of these becomes true:
-
-- all remaining todo items are `done`
-- remaining abandoned items are `skipped` with reasons
-- the agent is now waiting on a structured dependency such as `ask()` or another delegation
-
-## Telemetry and Tracing
-
-Important span events in the current implementation include:
-
-- `supervision.heuristics_registered`
-- `supervision.heuristic_checked`
-- `supervision.violation_detected`
-- `supervision.heuristic_skipped`
-- `executor.supervision_violation`
-- `executor.supervision_repeatable_gate_triggered`
-- `executor.supervision_final_correction`
-- `executor.supervision_correction`
-- `executor.supervision_pending_delegations`
-
-The most important recent addition is `supervision.heuristic_skipped`, which makes it visible when a heuristic did not run because it had already been enforced under `once-per-execution` semantics.
-
-## How To Extend This System Safely
-
-If you add or change a supervision heuristic:
-
-1. Decide whether it is a nudge or a gate.
-2. Set `enforcementMode` explicitly.
-3. Decide whether the detection is objective enough for `skipVerification`.
-4. Make sure the correction message points the agent toward structured state transitions, not just prose.
-5. Add integration coverage through `PostCompletionChecker` if the heuristic affects completion blocking.
-
-If you change retry behavior:
-
-1. check `SupervisorOrchestrator`
-2. check `PostCompletionChecker`
-3. check reminder queue semantics in `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md`
-4. check final publish behavior in `AgentExecutor`
-
-If you change the valid ways an agent can stop with unfinished work:
-
-1. update this document
-2. update the `pending-todos` correction copy
-3. update the relevant tool semantics such as `ask()` or `todo_write`
-4. add tests proving the new state is machine-visible to supervision
-
-## Files To Read First
-
-If you need to work on this subsystem, start here:
-
-- `src/agents/supervision/types.ts`
-- `src/agents/supervision/registerHeuristics.ts`
-- `src/agents/supervision/SupervisorOrchestrator.ts`
-- `src/agents/execution/PostCompletionChecker.ts`
-- `src/agents/execution/AgentExecutor.ts`
-- `src/agents/supervision/heuristics/PendingTodosHeuristic.ts`
-- `src/tools/implementations/ask.ts`
-- `src/tools/implementations/todo.ts`
-- `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md`
-- `docs/DELEGATION-AND-RAL-PROCESSING.md`
+This document explains how TENEX supervises agent executions: the post-completion
+gates and pre-tool checks that decide whether an agent's behavior should be
+corrected before a completion is published or a tool is allowed to run, and the
+structured-state exits that let an agent stop safely.
+
+## Ownership
+
+Supervision logic lives in the **`tenex-supervision`** crate. It is **pure**:
+no I/O, no async, no workspace dependencies — just heuristics over plain inputs,
+which makes it trivially unit-testable. The agent runner (`tenex-agent`) owns the
+side effects: it builds the context, calls the supervisor, and acts on the
+result inside its turn loop.
+
+The public surface:
+
+- `tenex_supervision::heuristics::default_supervisor() -> Supervisor`
+- `Supervisor::check_pre_tool(tool_name, todos, category) -> Option<String>` — a block reason, or `None`.
+- `Supervisor::check_post_completion(context) -> PostCompletionOutcome`
+- `Supervisor::record_tool_call(tool_name)` — feeds the tool-call counter.
+
+A fresh `Supervisor` is created per agent invocation. Its state (which
+once-per-execution heuristics have fired, which todos have reached a terminal
+status, the stuck/re-engagement counters) lives only for that invocation; there
+is no durable or cross-invocation retry tracking.
+
+## Two timings
+
+Supervision runs at two points:
+
+- **`pre-tool-execution`** — before a tool is allowed to run.
+- **`post-completion`** — when the agent tries to finish a turn.
+
+## Heuristics today
+
+### `pending-todos` (post-completion gate)
+Blocks completion while the agent still has `Pending` or `InProgress` todo items.
+It is a pure state check (no LLM). Its enforcement mode is **repeat-until-resolved**
+and it re-engages the agent. It is intentionally **suppressed** when:
+
+- the agent is waiting on structured external work (`pending_delegation_count > 0`, e.g. after `ask()`), or
+- the request was explicitly "set up a todo list and stop".
+
+### `consecutive-tools-without-todo` (post-completion nudge)
+After the agent has made several tool calls (threshold: 5) without ever creating
+a todo list, this nudges it to use `todo_write`. It is **once-per-execution**,
+does **not** re-engage (advisory only), and suppresses itself once the agent has
+been nudged.
+
+### `worker-todo-before-file-or-shell` (pre-tool gate)
+For agents in the `Worker` category, this blocks the protected tools (`shell`,
+the `fs_*` filesystem tools, the `home_*` tools) until the agent has created a
+todo list. It returns a block reason; the runner skips the tool with that reason.
+
+> The previous TypeScript runtime also had LLM-verified `silent-agent` and
+> `delegation-claim` heuristics. These are **not** implemented in Rust; every
+> current heuristic is a pure state check with no LLM verification. The missing
+> heuristics are tracked as parity gaps in `MIGRATION_PENDING.md`.
+
+## Outcomes
+
+`check_post_completion` returns one of:
+
+- **`Accept`** — supervision is satisfied; the runner proceeds to publish.
+- **`InjectMessage { message }`** — an advisory note; the completion is allowed
+  to finish and the message is surfaced, but it is not persisted and does not
+  re-run the agent.
+- **`ReEngage { message }`** — the turn must not complete yet. The runner
+  persists the message as a `supervision`-type user message and runs the agent
+  again instead of publishing.
+
+A `Detection` (`heuristic_name`, `message`, `enforcement`, `re_engage`) is the
+internal representation a heuristic produces; the supervisor maps it to one of
+the outcomes above.
+
+## Enforcement modes
+
+- **`OncePerExecution`** — once the heuristic fires, it is skipped on later
+  post-completion checks within the same invocation. Use for advisory nudges
+  where repeating would only add noise.
+- **`RepeatUntilResolved`** — re-evaluated on every completion attempt; firing
+  once does not exempt it later. Use for objective gates where "warning
+  delivered" is not the same as "condition resolved" (e.g. `pending-todos`).
+
+## Progress detection and the stuck cap
+
+Re-engaging gates cannot loop forever:
+
+- When a todo reaches a terminal status (`Done` or `Skipped`), the supervisor
+  counts that as progress and resets its stuck counter.
+- After `MAX_STUCK_ITERATIONS` (3) consecutive re-engagements with **no**
+  progress, the supervisor returns `Accept` — it stops blocking and lets the
+  completion through. (There is no separate "stronger final correction" message;
+  it simply accepts.)
+- An absolute backstop (`ABSOLUTE_REENGAGEMENT_CAP`, 30) accepts unconditionally
+  if re-engagements ever reach that count.
+
+## Post-completion flow
+
+1. When the agent finishes streaming, the turn loop builds a
+   `PostCompletionContext`: the current todos, the tool calls made this turn,
+   whether a todo nudge has already been delivered, the count of pending external
+   work, and the original triggering message.
+2. It calls `Supervisor::check_post_completion(...)`.
+3. On `ReEngage`, the runner persists the supervision message and loops the agent.
+   On `InjectMessage`, it publishes and surfaces the note. On `Accept`, it proceeds.
+4. On `Accept`, the runner still decides **what** to publish: if there is pending
+   external work or pending delegations, it emits an ordinary conversation
+   message (`ConversationIntent`); otherwise it emits a completion
+   (`CompletionIntent`) that marks the turn done. This publish decision is
+   separate from supervision.
+
+## Structured resolution paths
+
+Supervision deliberately prefers structured state changes over free-text excuses.
+An agent that cannot or should not keep working has these machine-visible exits:
+
+- **Continue the work** and update the todo list as progress changes.
+- **Call `ask()`** when human input or external confirmation is needed. This
+  marks pending external work, which suppresses the `pending-todos` gate.
+- **Mark todos `skipped`** (with a `skip_reason`) when an item is no longer
+  relevant. Skipped counts as progress.
+
+## Telemetry
+
+The `tenex-supervision` crate emits no telemetry of its own (it has no I/O). Any
+tracing or logging around supervision decisions happens in the `tenex-agent`
+turn loop that drives it.
+
+## Extending supervision
+
+When adding or changing a heuristic:
+
+1. Decide whether it is an advisory nudge or a gate, and set the enforcement mode
+   (`OncePerExecution` vs `RepeatUntilResolved`) accordingly.
+2. Keep it a pure function of its inputs — no I/O in `tenex-supervision`.
+3. Make the correction message point the agent toward a structured state change
+   (finish a todo, skip it with a reason, or `ask()`), not just prose.
+4. Wire pre-tool gates through `check_pre_tool` and post-completion gates through
+   `check_post_completion`, and cover the new behavior with crate-level tests.
+
+## Where to look
+
+- `crates/tenex-supervision/` (`supervisor.rs`, `heuristics/`, `types.rs`) and its `AGENTS.md`.
+- The post-completion gating and re-engagement loop in `crates/tenex-agent/src/turn_loop/`.
+- `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md` for how supervision messages reach the model-facing prompt.

--- a/docs/internals/conversation-metadata-generation.md
+++ b/docs/internals/conversation-metadata-generation.md
@@ -18,9 +18,7 @@ related_files:
   - "crates/tenex-summarizer/src/state.rs"
   - "crates/tenex-summarizer/src/categories.rs"
   - "tenex/src/daemon/mod.rs"
-  - "src/events/NDKEventMetadata.ts"
-  - "src/event-handler/index.ts"
-confidence: "high for current Rust source; medium for future tenex-conversations cutover"
+confidence: "high for current Rust source"
 ---
 
 # Conversation Metadata Generation
@@ -33,9 +31,9 @@ How does TENEX generate conversation metadata such as titles, summaries, status 
 
 The current Rust owner is `crates/tenex-summarizer`, a host-level companion daemon. The Rust `tenex daemon` starts it if a `tenex-summarizer` binary exists beside the `tenex` binary. The summarizer runs once per host, takes a singleton `flock` lock at `$TENEX_BASE_DIR/summarizer.pid`, polls every 5 seconds, and scans every project under `$TENEX_BASE_DIR/projects`.
 
-For now, the source adapter in `crates/tenex-summarizer/src/source.rs` reads the interim Bun-era storage layout: per-project JSON transcripts plus `conversation-catalog.db`. The catalog supplies candidate conversation ids and last-activity timestamps. The JSON transcript supplies text messages and receives the metadata writeback. The summarizer does not yet read or write the newer `crates/tenex-conversations` SQLite store directly.
+The source adapter in `crates/tenex-summarizer/src/source.rs` reads and writes the per-project `conversation.db` through the `tenex-conversations` `ConversationStore`. It lists candidate conversations from the `messages` table (by most recent message activity), builds transcripts from the stored messages, and writes generated metadata back through the store's `update_metadata`. It does not read JSON transcripts or any `conversation-catalog.db`.
 
-For each eligible conversation, the scheduler waits until the catalog last activity is at least 10 seconds quiet and not older than 7 days. It then checks `$TENEX_BASE_DIR/summarizer/state.db` so it only summarizes when activity has advanced, with a 5 minute per-conversation minimum interval. It formats text messages into a speaker-labeled transcript, asks the configured summarization LLM for a structured `Summary`, writes non-empty title/summary/status fields into the JSON `metadata` object, records category counts globally, and publishes an empty-content kind:513 event with `e`, `a`, `title`, `summary`, `status-*`, `t`, and `model` tags.
+For each eligible conversation, the scheduler waits until the last message activity is at least 10 seconds quiet and not older than 7 days. It then checks `$TENEX_BASE_DIR/summarizer/state.db` so it only summarizes when activity has advanced, with a 5 minute per-conversation minimum interval. It formats text messages into a speaker-labeled transcript, asks the configured summarization LLM for a structured `Summary`, writes non-empty title/summary/status fields to the conversation's header columns in `conversation.db`, records category counts globally, and publishes an empty-content kind:513 event with `e`, `a`, `title`, `summary`, `status-*`, `t`, and `model` tags.
 
 ## System Map
 
@@ -47,7 +45,7 @@ For each eligible conversation, the scheduler waits until the catalog last activ
 
 `crates/tenex-summarizer/src/scheduler.rs` owns process policy: scan cadence, quiet window, maximum age, per-conversation rate limit, error handling, category recording, and success/failure logs.
 
-`crates/tenex-summarizer/src/source.rs` is the only Rust summarizer module that knows the current on-disk conversation layout. It discovers projects, loads `event.json` for the project `a` tag, queries `conversation-catalog.db` for candidate rows, builds transcripts from JSON `messages`, and writes generated metadata back to the JSON file.
+`crates/tenex-summarizer/src/source.rs` is the only Rust summarizer module that knows the conversation store schema. It discovers projects, loads `event.json` for the project `a` tag, opens `conversation.db` through `tenex-conversations`, lists candidate conversations from the `messages` table, builds transcripts from the stored messages, and writes generated metadata back through `ConversationStore::update_metadata`.
 
 `crates/tenex-summarizer/src/summarize.rs` owns the LLM prompt and output schema. The schema uses snake-case fields at the LLM boundary: `title`, `summary`, `status_label`, `status_current_activity`, and `categories`.
 
@@ -55,40 +53,34 @@ For each eligible conversation, the scheduler waits until the catalog last activ
 
 `crates/tenex-summarizer/src/categories.rs` stores a global category tally at `$TENEX_BASE_DIR/data/conversation-categories.json`. The LLM receives the top 10 categories by frequency as canonical suggestions, not an allowlist.
 
-`src/events/NDKEventMetadata.ts` and `src/event-handler/index.ts` are still relevant on the TypeScript side. A runtime that receives kind:513 can apply `title`, `summary`, `status-label`, and `status-current-activity` tags to an in-memory `ConversationStore`, then save the transcript.
+Consuming the published kind:513 events — applying the `title`, `summary`, `status-label`, and `status-current-activity` tags back onto a conversation the runtime already knows — is a separate runtime concern from this publish-only daemon. The TypeScript consumers that previously did this (`NDKEventMetadata`, the event handler, and `ConversationCatalogService`) were removed in the cutover; see the addendum for how that path worked.
 
-`src/conversations/ConversationCatalogService.ts` is the derived read model for metadata queries in the interim TypeScript storage path. It mirrors metadata fields from JSON into `conversation-catalog.db`, but the Rust summarizer currently writes the JSON file directly and does not update the catalog DB itself.
+Generated metadata is written to the conversation's header columns in `conversation.db` via `ConversationStore::update_metadata`. There is no separate `conversation-catalog.db` in this path; the conversation store is the single substrate the summarizer reads and writes.
 
 ## Runtime Flow
 
 1. `tenex daemon` starts, resolves its base directory, and spawns `tenex-summarizer` as a supervised companion when the binary is present beside `tenex`.
 2. `tenex-summarizer run` initializes telemetry/logging, acquires `$TENEX_BASE_DIR/summarizer.pid`, loads config, opens `$TENEX_BASE_DIR/summarizer/state.db`, creates a Nostr publisher, and starts a 5 second ticker.
-3. Each scan calls `source::discover_projects()`. A project is considered only when `$TENEX_BASE_DIR/projects/<dTag>/conversation-catalog.db` exists. Missing catalogs are skipped because projects can exist before the catalog is populated.
+3. Each scan calls `source::discover_projects()` (via `tenex-conversations`). A project is considered only when both its `event.json` and `conversation.db` exist.
 4. For each project, `source::load_project_event()` reads `event.json` and extracts the project owner pubkey plus d-tag. This becomes the kind:513 `a` tag value `31933:<pubkey>:<dTag>`.
-5. `source::list_candidates()` opens the project catalog read-only and selects conversations whose `last_activity` is between `now - 7 days` and `now - 10 seconds`, newest first.
-6. `scheduler::should_process()` reads the summarizer state row keyed by `conversation_id`. New conversations process once. Existing rows process only when catalog `last_activity` is greater than the last summarized activity and at least 5 minutes have elapsed since the last successful or empty-content handling.
-7. `source::fetch_content()` reads `<project>/conversations/<conversation_id>.json`, keeps only messages with `messageType == "text"`, formats each as `speaker: content`, and joins messages with blank lines. Speaker selection prefers `senderPrincipal.displayName`, then `senderPrincipal.username`, then the first 8 chars of `senderPubkey`, then `system` for system-role messages, then `unknown`.
+5. `source::list_candidates()` opens `conversation.db` and selects conversations from the `messages` table, grouped by `conversation_id` by most recent message activity, whose last activity is between `now - 7 days` and `now - 10 seconds`, newest first.
+6. `scheduler::should_process()` reads the summarizer state row keyed by `conversation_id`. New conversations process once. Existing rows process only when the last message activity is greater than the last summarized activity and at least 5 minutes have elapsed since the last successful or empty-content handling.
+7. `source::fetch_content()` reads the conversation's messages from `conversation.db` via `list_messages`, keeps only messages with `message_type == "text"`, formats each as `speaker: content`, and joins messages with blank lines. Speaker selection uses `system` for system-role messages, then `senderPrincipal.displayName`, then `senderPrincipal.username`, then the first 8 chars of the sender/author pubkey, then `unknown`.
 8. `summarize::summarize()` passes the transcript and category suggestion text to a Rig extractor for the configured provider. The system prompt instructs the model to avoid invented outcomes, keep titles to 3-5 words, keep summaries to one dense sentence under 160 characters, choose one of the fixed status labels, and emit 0-3 stable lowercase category nouns.
-9. `scheduler::process_inner()` converts non-empty LLM fields into a `MetadataUpdate`. It writes `title`, `summary`, `statusLabel`, and `statusCurrentActivity` into the JSON conversation `metadata` object. Empty fields are ignored rather than deleting old metadata.
+9. `scheduler::process_inner()` converts non-empty LLM fields into a `MetadataUpdate` and writes `title`, `summary`, `status_label`, and `status_current_activity` through `ConversationStore::update_metadata` into the conversation's header columns in `conversation.db`. Empty fields are ignored rather than deleting old metadata.
 10. The publisher emits a kind:513 event with tags for the conversation id, metadata fields, categories, project `a` reference, and model id. The event content is empty.
 11. After `process_inner()` succeeds, the scheduler records `(conversation_id, last_activity_summarized, last_summarized_at_ms)` in `state.db`. It then increments category counts for any returned categories and logs `summarized`.
 
 ## State And Data
 
-The local metadata shape in JSON transcripts is camel-case:
+Metadata is stored on the conversation row in `conversation.db`, set via `update_metadata`. The four fields written are:
 
-```json
-{
-  "metadata": {
-    "title": "Runtime Probe Fix",
-    "summary": "Probe replay waits were adjusted after flaky runtime timing.",
-    "statusLabel": "Completed",
-    "statusCurrentActivity": "Runtime probe expectations now match replay timing."
-  }
-}
-```
+- `title`
+- `summary`
+- `status_label`
+- `status_current_activity`
 
-Category tags are not written into the conversation JSON metadata by the Rust summarizer. They are published as Nostr `t` tags and counted in the global category tally.
+Category tags are not written into the conversation metadata by the Rust summarizer. They are published as Nostr `t` tags and counted in the global category tally.
 
 The kind:513 event contract uses tag names rather than JSON content:
 
@@ -103,27 +95,25 @@ The kind:513 event contract uses tag names rather than JSON content:
 ["model", "<model-id>"]
 ```
 
-The summarizer state DB is independent of project catalog state. Its `conversation_summary_state` table stores only the conversation id, the catalog last-activity value that was handled, and the wall-clock summarize time in milliseconds. This implies the architecture treats Nostr conversation event ids as globally unique enough for host-wide state keys.
+The summarizer state DB is independent of the conversation store. Its `conversation_summary_state` table stores only the conversation id, the last message-activity value that was handled, and the wall-clock summarize time in milliseconds. This implies the architecture treats Nostr conversation event ids as globally unique enough for host-wide state keys.
 
-The interim `conversation-catalog.db` stores title, summary, last user message, status label, current activity, timestamps, participants, delegations, and embedding index state. `ConversationCatalogService` derives those fields by parsing JSON transcripts or by receiving `ConversationStore.save()` upserts. A direct Rust `source::write_metadata()` changes the JSON transcript but does not directly upsert the catalog.
-
-The newer `crates/tenex-conversations` schema already has first-class conversation header columns for title, summary, last user message, status label, status current activity, owner pubkey, timestamps, and `metadata_json`. The summarizer adapter has not been switched to that store in the reviewed source.
+The `tenex-conversations` schema has first-class conversation header columns for title, summary, last user message, status label, status current activity, owner pubkey, timestamps, and `metadata_json`. The summarizer writes the title/summary/status fields into those columns via `update_metadata`. (Previously, the now-removed TypeScript `ConversationCatalogService` derived such fields from JSON transcripts and `ConversationStore.save()` upserts — see the addendum.)
 
 ## Contracts And Invariants
 
-Only `source.rs` should know the current transcript storage layout. The rest of the summarizer is intentionally storage-agnostic so the JSON+catalog adapter can be replaced when `tenex-conversations` becomes the runtime conversation store.
+Only `source.rs` knows the conversation store schema. The rest of the summarizer is intentionally storage-agnostic; the adapter targets the `tenex-conversations` `ConversationStore`.
 
 The summarizer is publish-only. It does not subscribe to relays, route inbound events, execute agents, manage RAL state, or mutate project membership.
 
 The LLM schema is a compatibility contract. The Rust prompt and schema were lifted from the removed TypeScript `ConversationSummarizer`; changing either should be treated as a wire/behavior change, not a local refactor.
 
-The local write uses camel-case status keys, while the kind:513 event uses kebab-case tag keys and the LLM schema uses snake-case field names. Future agents should preserve this mapping unless they update every reader.
+There are three distinct representations of the same fields: the conversation store columns (`status_label`, `status_current_activity`), the kind:513 event's kebab-case tag keys (`status-label`, `status-current-activity`), and the snake-case LLM schema fields. Future agents should preserve this mapping unless they update every reader.
 
-The event should include an `e` tag for the conversation id and an `a` tag for the project coordinate. The TypeScript daemon classification path treats kind:513 as conversation-plane traffic, and the event handler updates only conversations it already knows.
+The event should include an `e` tag for the conversation id and an `a` tag for the project coordinate. Consumers classify kind:513 as conversation-plane traffic and update only conversations they already know.
 
 The current Rust transcript formatter ignores tool-call, tool-result, and delegation-marker messages. Generated metadata is therefore based only on text conversation entries.
 
-The singleton lock is part of the correctness model. Two host summarizers would race on JSON writes, duplicate kind:513 events, and double-count categories.
+The singleton lock is part of the correctness model. Two host summarizers would race on metadata writes, duplicate kind:513 events, and double-count categories.
 
 ## Failure And Recovery
 
@@ -131,15 +121,15 @@ If config is missing, no valid relay remains, no backend secret key exists, or t
 
 If project discovery fails, the scan logs a warning and continues on the next tick. If one project has an unreadable `event.json`, only that project is skipped. If listing candidates fails for one project, the scan continues to the next project.
 
-If a candidate's JSON transcript is missing or produces an empty transcript, `process_inner()` returns `Ok(None)`. The scheduler still records the catalog last-activity value in state, so the same empty candidate is not retried until activity advances.
+If a candidate conversation is missing from the store or produces an empty transcript, `process_inner()` returns `Ok(None)`. The scheduler still records the last message-activity value in state, so the same empty candidate is not retried until activity advances.
 
-If the LLM call, JSON metadata write, signing, or publish fails, the scheduler logs `summarize failed` and does not record state. The next scan can retry the same candidate. Because JSON write happens before publish, a publish failure can leave local JSON metadata updated even though the summarizer will retry and potentially publish later.
+If the LLM call, metadata write, signing, or publish fails, the scheduler logs `summarize failed` and does not record state. The next scan can retry the same candidate. Because the metadata write happens before publish, a publish failure can leave the stored metadata updated even though the summarizer will retry and potentially publish later.
 
 If category tally recording fails after successful metadata generation and publishing, the scheduler logs a warning but keeps the summarization state. Category tally failure does not retry the conversation.
 
 There is no explicit LLM timeout or parallel worker pool in the reviewed scheduler. A slow LLM call blocks subsequent candidate processing in that daemon process until it returns or fails.
 
-The Rust direct JSON write preserves other top-level transcript fields and writes through a temporary `*.json.tmp` followed by rename. It does not coordinate with a simultaneously saving TypeScript `ConversationStore`, so the singleton summarizer prevents summarizer/summarizer races but not every possible cross-process JSON write race in the interim layout.
+The metadata write goes through `ConversationStore::update_metadata` against `conversation.db`. The singleton summarizer lock prevents summarizer/summarizer races; the store is the same SQLite file other consumers open, so concurrency is mediated by SQLite rather than by file-rename semantics.
 
 ## Observability
 
@@ -149,9 +139,7 @@ The `status` subcommand probes the lockfile and prints `running (pid <pid>)` or 
 
 The current Rust code initializes `tenex_telemetry`, but the summarizer path reviewed here relies on logs rather than a detailed span model. This differs from the old TypeScript path, which created a `tenex.summarize` OpenTelemetry span for each summarization.
 
-`crates/tenex-summarizer/tests/discover_and_read.rs` is the focused Rust test. It builds an isolated `$TENEX_BASE_DIR`, creates a project fixture with `event.json`, `conversation-catalog.db`, and JSON transcript, then verifies discovery, candidate listing, transcript formatting, state recording, and metadata writeback. It intentionally stops at the LLM boundary.
-
-Useful TypeScript validation remains around kind:513 consumption and catalog projection: `src/event-handler/index.ts` applies metadata event tags to known conversations, and `src/conversations/ConversationCatalogService.ts` projects JSON metadata into catalog rows.
+`crates/tenex-summarizer/tests/discover_and_read.rs` is the focused Rust test. It builds an isolated `$TENEX_BASE_DIR`, creates a project fixture with `event.json` and a `conversation.db`, then verifies discovery, candidate listing, transcript formatting, state recording, and metadata writeback. It intentionally stops at the LLM boundary.
 
 ## Source Guide
 
@@ -159,7 +147,7 @@ Read `crates/tenex-summarizer/AGENTS.md` first for the local invariants: polling
 
 Read `crates/tenex-summarizer/src/scheduler.rs` for scan timing, candidate policy, state decisions, and retry behavior.
 
-Read `crates/tenex-summarizer/src/source.rs` for the current storage adapter, transcript formatter, project event loading, candidate SQL, and JSON metadata write.
+Read `crates/tenex-summarizer/src/source.rs` for the conversation-store adapter, transcript formatter, project event loading, candidate SQL, and the `update_metadata` write.
 
 Read `crates/tenex-summarizer/src/summarize.rs` for the exact LLM prompt, structured output schema, provider support, and category suggestion injection.
 
@@ -169,15 +157,11 @@ Read `crates/tenex-summarizer/src/config.rs`, `state.rs`, `categories.rs`, and `
 
 Read `tenex/src/daemon/mod.rs` and `tenex/src/daemon/supervisor.rs` to understand how the daemon is launched and restarted.
 
-Read `src/events/NDKEventMetadata.ts`, `src/event-handler/index.ts`, `src/conversations/ConversationStore.ts`, and `src/conversations/ConversationCatalogService.ts` for remaining TypeScript consumers of generated metadata.
-
-Read `crates/tenex-conversations/src/schema.rs`, `model.rs`, `store.rs`, and `migration.rs` before moving the summarizer off JSON transcripts.
+Read `crates/tenex-conversations/src/schema.rs`, `model.rs`, `store.rs`, and `migration.rs` for the conversation store schema the summarizer reads and writes.
 
 ## Open Questions
 
-The source adapter still targets JSON transcripts plus `conversation-catalog.db`. The intended `tenex-conversations` SQLite cutover is documented, but the reviewed source has not implemented it.
-
-The Rust summarizer writes JSON metadata directly and does not update `conversation-catalog.db` or embedding index state directly. Catalog consumers that reconcile from disk will eventually see the metadata, but there is no immediate Rust-side catalog upsert in this path.
+The summarizer writes conversation header metadata but does not update embedding index state. RAG indexing is a separate concern owned by `tenex-embedder`.
 
 The Rust transcript formatter does not use `tenex-identity` for pubkey display-name resolution. It falls back to sender-principal fields or short pubkeys, which may produce lower-fidelity speaker labels than the old TypeScript `IdentityService` path.
 
@@ -189,13 +173,13 @@ TypeScript comparison reference: local git object `2855d63d93dee6a708800d6d9b8f4
 
 In TypeScript, `ConversationSummarizer` and `MetadataDebounceManager` lived inside the project runtime. `AgentDispatchService` invoked them on new conversations, after normal agent dispatch, and after delegation response handling. The cutover commit deleted those services and callsites so the Rust daemon owns kind:513 generation.
 
-The trigger model changed. TypeScript generated initial metadata immediately for a new non-internal conversation, then used in-memory per-conversation debounce timers: agent start cleared pending timers, subsequent completions waited 10 seconds, and a 5 minute max deadline forced publication. Rust polls catalog activity instead. It waits for at least 10 seconds of quiet time, processes on the next 5 second scan, and hard-caps re-summarization to once every 5 minutes after a successful or empty-content handling.
+The trigger model changed. TypeScript generated initial metadata immediately for a new non-internal conversation, then used in-memory per-conversation debounce timers: agent start cleared pending timers, subsequent completions waited 10 seconds, and a 5 minute max deadline forced publication. Rust polls message activity instead. It waits for at least 10 seconds of quiet time, processes on the next 5 second scan, and hard-caps re-summarization to once every 5 minutes after a successful or empty-content handling.
 
 The failure boundary changed. In TypeScript, a hung or crashing summarization call shared a process with agent dispatch. In Rust, summarization is a supervised host daemon; crashes can be restarted without taking down agent execution, and pending work is rediscovered from disk.
 
 The debounce state changed from volatile timers to durable SQLite state. TypeScript lost pending timers on runtime shutdown. Rust records last summarized activity in `$TENEX_BASE_DIR/summarizer/state.db`, so restart does not resummarize the whole host.
 
-The data access path changed. TypeScript summarized a live `ConversationStore`, saved through `ConversationStore.save()`, updated `ConversationCatalogService`, and triggered indexing hooks. Rust reads and writes JSON directly through `source.rs`; this preserves local transcript metadata but bypasses immediate TypeScript catalog/index hooks.
+The data access path changed. TypeScript summarized a live in-memory `ConversationStore`, saved through `ConversationStore.save()`, updated `ConversationCatalogService`, and triggered indexing hooks. Rust reads and writes the SQLite `conversation.db` directly through `source.rs` (via the `tenex-conversations` `ConversationStore`), with no separate catalog or index-hook step.
 
 The LLM prompt and schema are intentionally the same. TypeScript used `llmServiceFactory.generateObject()` with a Zod schema. Rust uses Rig extractors with a serde/schemars `Summary` struct. The field names and prompt text are parity-sensitive.
 

--- a/docs/internals/delegation-runtime.md
+++ b/docs/internals/delegation-runtime.md
@@ -2,17 +2,29 @@
 title: "Delegation Runtime"
 date: "2026-04-29"
 audience: "llms"
-scope: "How TENEX agents create delegated work, route completions, resume parent RALs, and represent delegation state in the current TypeScript runtime, with Rust intent-path notes where they affect the shared protocol."
-status: "investigated"
+scope: "HISTORICAL REFERENCE. How the now-removed TypeScript runtime represented delegated work, routed completions, and resumed parent RALs, with Rust intent-path notes where they affect the shared protocol. For current Rust behavior, see the documents linked below."
+status: "historical"
 related_docs:
-  - "docs/DELEGATION-AND-RAL-PROCESSING.md"
   - "docs/internals/ral-lifecycle-and-mid-run-injection.md"
-  - "docs/SUPERVISION.md"
+  - "docs/internals/delegation-followup-runtime.md"
   - "docs/RUST-AGENT-SPEC.md"
-confidence: "high for the TypeScript runtime, medium for Rust parity"
+confidence: "describes the removed TypeScript runtime; the current Rust runtime differs"
 ---
 
 # Delegation Runtime
+
+> **Historical reference.** This document describes the delegation/RAL model of
+> the **now-removed TypeScript runtime** (`RALRegistry`, `AgentDispatchService`,
+> the `src/services/ral/` and `src/agents/execution/` machinery). The Rust
+> system does not replicate that in-memory RAL orchestration; its delegation
+> path is simpler and persists routes in `conversation.db`. It is kept as a
+> record of the prior design (the TypeScript reference worktree noted in the
+> top-level `AGENTS.md` still holds the source).
+>
+> For how delegation works in the **current Rust runtime**, see:
+> - `docs/internals/ral-lifecycle-and-mid-run-injection.md`
+> - `docs/internals/delegation-followup-runtime.md`
+> - the Rust intent path in `crates/tenex-agent/src/tools/delegate.rs`, `delegate_followup.rs`, `self_delegate.rs`, and `crates/tenex-protocol/`.
 
 ## Question
 
@@ -20,7 +32,7 @@ How does TENEX represent a delegated task, route it to another agent, wait for i
 
 ## Short Answer
 
-In the current TypeScript runtime, a delegation is a fresh kind:1 Nostr event from the delegating agent to the delegatee. It p-tags the delegatee, has no root `e` tag, and is treated as the root of the child conversation. `AgentPublisher.delegate()` also adds a `delegation` tag pointing back to the parent conversation so the child conversation can build a delegation chain.
+In the TypeScript runtime, a delegation was a fresh kind:1 Nostr event from the delegating agent to the delegatee. It p-tags the delegatee, has no root `e` tag, and is treated as the root of the child conversation. `AgentPublisher.delegate()` also adds a `delegation` tag pointing back to the parent conversation so the child conversation can build a delegation chain.
 
 The parent RAL does not end when the tool publishes the delegation. The tool immediately registers a `PendingDelegation` in `RALRegistry`, while `PendingDelegationsRegistry` holds the published event id long enough for `ToolExecutionTracker` to add a q-tag to the delayed tool-use event. The executor may keep streaming, but final completion is blocked while pending or completed delegation work remains.
 

--- a/docs/system-prompt-architecture.md
+++ b/docs/system-prompt-architecture.md
@@ -1,83 +1,112 @@
 # TENEX System Prompt Construction
 
-This document describes the current system prompt architecture in TENEX. The key distinction is that lesson handling is no longer part of prompt assembly. Lessons and lesson comments are compiled ahead of time into each agent's Effective Agent Instructions, and the prompt builder only reads that compiled result.
+This document describes how TENEX assembles an agent's system prompt. The
+central property is **determinism**: assembly is a pure function of its inputs,
+with no background compilation, no caching layer, and no separate "effective
+instructions" step. Identical inputs produce a byte-identical prompt, which is
+what makes the prompt a stable cache anchor for downstream LLM calls.
 
-## 1. High-Level Flow
+## 1. Ownership
 
-1. `ProjectRuntime.start()` creates a `ProjectContext` and a project-scoped `PromptCompilerRegistryService`.
-2. The registry registers every agent in that runtime and creates one `PromptCompilerService` per agent.
-3. Lesson and lesson-comment events are stored in `ProjectContext`.
-4. `ProjectContext` synchronizes the affected agent's lesson/comment snapshot into the registry.
-5. The per-agent compiler recompiles Effective Agent Instructions in the background.
-6. `buildSystemPromptMessages()` reads those compiled instructions synchronously and builds the rest of the prompt around them.
+System-prompt assembly is owned by the **`tenex-system-prompt`** crate. Its
+`build_system_prompt` entry point is a pure, synchronous, I/O-free function: it
+takes already-resolved inputs and returns the assembled prompt string. It does
+not read the filesystem, open relays, or call an LLM.
 
-The runtime never blocks an agent turn on compilation. If a recompile is in progress, TENEX serves the last good compiled instructions. If nothing has ever compiled yet, TENEX falls back to the base `agent.instructions`.
+The **`tenex-agent`** runner is responsible for *gathering* those inputs during
+agent bootstrap — discovering the agent home, reading project instructions,
+resolving skills and workflows, loading project context — and then calling
+`build_system_prompt`. Caching the resulting prompt across turns (for prompt-
+cache reuse) is the runner's concern, not the assembler's.
 
-## 2. Ownership Boundaries
+This replaces the old runtime's background "prompt compiler" model entirely.
+There is no service that recompiles instructions ahead of time and no
+"Effective Agent Instructions" artifact; the prompt is recomputed from inputs
+each time it is needed.
 
-### Runtime-owned compilation
-- **`src/daemon/ProjectRuntime.ts`** owns compiler lifecycle.
-- **`src/services/prompt-compiler/PromptCompilerRegistryService.ts`** is the project-scoped coordinator.
-- **`src/services/prompt-compiler/prompt-compiler-service.ts`** is the per-agent worker that performs LLM synthesis, debouncing, disk caching, and kind:0 publishing.
-- **`src/services/projects/ProjectContext.ts`** is the source of truth for lessons and lesson comments and triggers registry synchronization after mutations.
+## 2. Assembly Order
 
-### Read-only prompt assembly
-- **`src/prompts/utils/systemPromptBuilder.ts`** does not construct prompt compilers, subscribe to lesson comments, or append raw lessons/comments.
-- It only resolves Effective Agent Instructions from `ProjectContext.promptCompilerRegistry` and injects them into the normal fragment pipeline by replacing `agent.instructions` for fragment rendering.
+`build_system_prompt` emits fragments in a fixed order. Order, field layout, and
+whitespace are part of the determinism contract — they must not vary for equal
+inputs. The fragments, in sequence:
 
-## 3. Effective Agent Instructions
+1. **Agent identity** — name, short pubkey, optional category.
+2. **Global system prompt** — injected when configured.
+3. **Home directory** — the agent's injected home files (see §4), wrapped in a
+   `<memorized-files>` block inside `<home-directory>`.
+4. **System-reminders explanation** — static guidance that system reminders are
+   background context, not user speech.
+5. **Agent instructions** — the agent's configured base instructions.
+6. **Preloaded skills** — the rendered list of available skill references.
+7. **Workflows** — the agent's authored workflows (`$AGENT_HOME/workflows/*.yaml`).
+8. **Environment variables** — `$AGENT_HOME`, `$PUBKEY`, `$PROJECT_BASE`,
+   `$PROJECT_ID`, `$TENEX_BASE_DIR`, etc. Skipped for workspace-restricted
+   categories.
+9. **Project context** — project title/id/owner/conversation id, plus a
+   `<workspace>` block (root path, branch, worktrees, cwd), a `<channels>` block
+   for Telegram bindings, and an `<agents.md>` block (see §5).
+10. **Available agents** — teammates, other teams, and unaffiliated agents,
+    filtered by the active team.
+11. **Todo guidance** and **tool-description guidance** — static guidance.
+12. **Category-specific guidance** — orchestrator / principal / domain-expert
+    guidance and delegation tips, selected by the agent's category.
+13. **Telegram chat context** and **delivery rules** — when the trigger arrived
+    via Telegram and/or the agent has Telegram bindings.
+14. **Scheduled tasks** — recurring and one-off tasks with next-run times, when
+    present.
 
-The Effective Agent Instructions are the compiled instruction set used by the agent at runtime. They contain only:
+Optional fragments are omitted when their input is absent, but the relative
+order of whatever remains is fixed.
 
-- Base Agent Instructions from `agent.instructions`
-- Agent lessons
-- Lesson comments
+> **Conversation reminders are not part of the system prompt.** They are built
+> by the runner and injected into the **user message**, not into the system
+> prompt, so they never perturb the cache anchor. See
+> `docs/CONTEXT-MANAGEMENT-AND-REMINDERS.md`.
 
-Project context, tools, skills, MCP resources, worktree state, and the rest of the normal system prompt are still added later as prompt fragments. They are not part of the lesson compilation step.
+## 3. Lessons
 
-## 4. Prompt Builder Composition
+Lessons are not compiled into the prompt by a background process, and they are
+not stored in any database. The mechanism is the agent home:
 
-After resolving Effective Agent Instructions, the prompt builder assembles the normal fragment stack:
+- The `learn` tool (in `tenex-agent`) maintains a single `+INDEX.md` file in the
+  agent's home directory. When an agent records a lesson, the tool asks an LLM
+  to **merge** the new lesson into the existing `+INDEX.md`, organized by
+  category, and writes the result back **synchronously**.
+- `+INDEX.md` is not special-cased at assembly time. It is injected because it
+  is a `+`-prefixed home file (see §4), like any other.
 
-- Agent identity and home directory
-- System-reminder explanation
-- Global system prompt
-- Environment and transport context
-- Meta-project and conversation context
-- Skills
-- Worktree and AGENTS.md guidance
-- Core runtime fragments such as scheduled tasks, MCP resources, RAG collection stats, and memorized reports
-- Agent-specific fragments such as available agents and delegation guidance
+This is the intentional divergence from the previous runtime, where lessons and
+lesson comments were compiled into instructions out of band. Here, lessons live
+as an LLM-maintained Markdown file that is injected like any other home file.
 
-The old "retrieved lessons" fallback path is not part of normal prompt construction anymore. Lessons influence behavior through compiled instructions, not raw fragment injection.
+## 4. The Agent Home
 
-## 5. Cache and Freshness Model
+Each agent has a home directory at `<base_dir>/home/<first-8-hex-of-pubkey>`.
 
-`PromptCompilerService` keeps a last-good compiled cache both in memory and on disk. Freshness is determined by:
+At bootstrap, the runner reads files in that directory whose names start with
+`+`, sorted by name. Up to 10 such files are injected, each truncated to a
+bounded length, into the home-directory fragment. This is the single mechanism
+by which durable, agent-authored context (lessons via `+INDEX.md`, plus any
+other `+`-prefixed notes) reaches the prompt.
 
-- the latest `created_at` across synchronized lessons and lesson comments
-- the current base instructions and agent definition event ID
+## 5. Project Instructions
 
-When those inputs change:
+The runner reads the project's root `AGENTS.md` and injects it into the
+`<project-context>` block, but only when it is below a small size bound (so a
+large `AGENTS.md` does not dominate the prompt). When absent or over the bound,
+the block is omitted.
 
-- background recompilation is triggered
-- stale compiled instructions remain usable until the new compile completes
-- base instructions are used only if no compiled result exists yet
+## 6. Design Intent
 
-## 6. Event Ingestion
+Keeping assembly pure and deterministic has three consequences that the rest of
+the system depends on:
 
-Lesson and lesson-comment ingestion happens outside the compiler:
-
-- **`src/daemon/Daemon.ts`** hydrates incoming lesson and lesson-comment events into active runtimes
-- **`src/event-handler/index.ts`** stores runtime-local lesson events in `ProjectContext`
-
-The compiler does not own NDK subscriptions, EOSE coordination, or comment-event parsing.
-
-## 7. Design Intent
-
-This split keeps the lesson system adaptive without putting compiler lifecycle, cache management, and event-ingestion logic on the prompt hot path:
-
-- lesson/comment event arrives
-- runtime updates project state
-- runtime-owned compiler recompiles in background
-- future prompts read compiled instructions synchronously
+- **Cache stability.** Equal inputs yield an identical prompt, so prompt caching
+  upstream is reliable. Anything that should vary turn-to-turn (reminders,
+  freshly retrieved context) goes into the user message instead.
+- **No hidden lifecycle.** There is no compiler to start, no cache to invalidate,
+  no recompile to wait on. The prompt is a function of inputs the runner already
+  has.
+- **Clear ownership.** `tenex-system-prompt` decides *shape and order*;
+  `tenex-agent` decides *what the inputs are*. Changing the assembled output
+  means changing one pure function, not coordinating a background subsystem.


### PR DESCRIPTION
The TypeScript runtime has been removed; the system now lives in the Rust workspace. This updates every doc that described how things worked under TypeScript, and fixes two doc-vs-code drifts found while verifying.

## Rewritten for the Rust crate workspace
- `docs/ARCHITECTURE.md`, `CLAUDE.md` (language-agnostic principle blocks kept verbatim), `docs/CONTRIBUTING.md`, `README.md`

## Subsystem behavior docs — rewritten, grounded in the actual crates
- `system-prompt-architecture.md` — no `PromptCompilerService`; deterministic `tenex-system-prompt` assembly + `+INDEX.md`
- `CONVERSATION-ID-ARCHITECTURE.md` — no Catalog/Presenter split; single `ConversationStore`
- `SUPERVISION.md` — `tenex-supervision` heuristics (corrected the false "final correction" claim)
- `CONTEXT-MANAGEMENT-AND-REMINDERS.md` — `tenex-context` 5-strategy projection pipeline
- `CONVERSATION_INDEXING.md` — `tenex-embedder` relay-walking daemon

## Reframed as historical references (TS RAL model Rust doesn't replicate)
- `docs/internals/delegation-runtime.md`, `docs/DELEGATION-AND-RAL-PROCESSING.md` — banner + redirect to the current Rust docs

## Surgical fixes
- `docs/internals/conversation-metadata-generation.md` — corrected false present-tense TypeScript claims
- `docs/RUST-AGENT-SPEC.md` — dropped a stale `no_response.ts` comparison

## Doc-vs-code drifts fixed (found while verifying)
- `tenex-embedder` reads relay kind:1 events into the **global** RAG store (not `conversation.db` into per-project stores) — fixed in `ARCHITECTURE.md` + `MODULE_INVENTORY.md`
- `tenex-summarizer` has **cut over to `conversation.db`** (no JSON transcript / catalog) — fixed in `conversation-metadata-generation.md`

`scripts/*.ts` dev tooling is retained, so its references are intentionally left intact. `docs/plans/*`, `docs/ideas/*`, `MIGRATION_PENDING.md`, `tui-port/*`, `CHANGELOG.md`, and the `AGENTS.md` "TypeScript Reference" pointer are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)