### PR TITLE
fix(agent): address review feedback on project hooks system

### DIFF
--- a/crates/tenex-agent/src/hook.rs
+++ b/crates/tenex-agent/src/hook.rs
@@ -95,9 +95,7 @@ impl EmitHook {
         }
     }
 
-    /// Take all pending project-hook injection strings. Called by the turn
-    /// loop after a tool's `post-tool` hooks fire, so the strings land on the
-    /// tool result the model reads next.
+    /// Take all pending project-hook injection strings for folding into the next tool result.
     pub fn drain_hook_injections(&self) -> Vec<String> {
         std::mem::take(&mut *self.hook_injections.lock().unwrap())
     }
@@ -248,9 +246,8 @@ impl EmitHook {
         args: &str,
         result: &str,
     ) -> HookAction {
-        // Project `post-tool` hooks observe the completed call. The tool has
-        // already run, so they cannot abort it; their stdout queues for
-        // injection into the result the model reads next.
+        // The tool already ran, so `post-tool` hooks cannot abort it; their
+        // stdout only queues for injection.
         if let Some(runner) = &self.project_hooks {
             let injections = runner.fire_post_tool(tool_name, args, result).await;
             self.hook_injections.lock().unwrap().extend(injections);
@@ -303,9 +300,7 @@ impl EmitHook {
         let name = tool_name.to_string();
         let args_string = args.to_string();
 
-        // Project hooks gate the call before the supervisor policy runs: a
-        // workspace `.tenex-hooks.json` `pre-tool` hook can block the tool
-        // outright or contribute context for the next LLM call.
+        // Project hooks gate the call before the supervisor policy runs.
         if let Some(runner) = &self.project_hooks {
             match runner.fire_pre_tool(tool_name, args).await {
                 PreToolOutcome::Block(reason) => return ToolCallHookAction::skip(reason),

--- a/crates/tenex-agent/src/project_hooks.rs
+++ b/crates/tenex-agent/src/project_hooks.rs
@@ -1,16 +1,4 @@
-//! Project-local hooks: Claude Code-compatible shell commands that fire at
-//! `pre-tool` and `post-tool` boundaries.
-//!
-//! Hooks are configured in `.tenex-hooks.json` in the agent's workspace
-//! directory. Each hook receives JSON context on stdin and can:
-//! - **block** a tool call (exit non-zero on `pre-tool`), or
-//! - **inject** context into the conversation (non-empty stdout on exit 0).
-//!
-//! The hook protocol is intentionally language-agnostic: hooks are plain
-//! shell commands, so any Claude Code-compatible hook (e.g. proactive-context)
-//! works without bespoke integration. This crate owns spawning and the
-//! stdin/stdout contract; [`crate::hook::EmitHook`] owns wiring the outcomes
-//! into the tool-call lifecycle.
+//! Project-local `.tenex-hooks.json` shell commands that fire at `pre-tool` and `post-tool` boundaries.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -196,10 +184,10 @@ impl ProjectHooksRunner {
                     );
                 }
                 HookRun::SpawnFailed(e) => {
-                    eprintln!(
-                        "[tenex-agent] warn: pre-tool hook '{}' failed to run: {e}; continuing",
+                    return PreToolOutcome::Block(format!(
+                        "pre-tool hook '{}' could not run: {e}",
                         hook.name
-                    );
+                    ));
                 }
             }
         }
@@ -264,7 +252,10 @@ impl ProjectHooksRunner {
             .current_dir(&self.working_dir)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            // On timeout the wait future is dropped; without this the OS
+            // process would be detached and orphaned.
+            .kill_on_drop(true);
 
         let mut child = match command.spawn() {
             Ok(child) => child,
@@ -438,6 +429,23 @@ mod tests {
         let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
         match runner.fire_pre_tool("shell", "{}").await {
             PreToolOutcome::Block(reason) => assert!(reason.contains("silent-block")),
+            other => panic!("expected block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pre_tool_spawn_failure_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = ProjectHooksConfig {
+            hooks: vec![HookEntry {
+                name: "missing".into(),
+                command: vec!["/nonexistent/hook-binary".into()],
+                events: vec![HookEvent::PreTool],
+            }],
+        };
+        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        match runner.fire_pre_tool("shell", "{}").await {
+            PreToolOutcome::Block(reason) => assert!(reason.contains("missing")),
             other => panic!("expected block, got {other:?}"),
         }
     }

--- a/crates/tenex-agent/src/turn_loop/step/tools.rs
+++ b/crates/tenex-agent/src/turn_loop/step/tools.rs
@@ -25,15 +25,12 @@ where
 {
     let mut records = Vec::with_capacity(tool_calls.len());
     for tool_call in tool_calls {
-        let records_before = records.len();
         let tool_call_id = tool_call.provider_tool_call_id();
         let args = tool_call.function_arguments_string();
         let tool_name = tool_call.tool_call.function.name.clone();
         let provider_call_id = tool_call.tool_call.call_id.clone();
-        // `is_error` flows through to projection via the `ToolCallRecord`s
-        // emitted by `recorder.take_records()` / `tool_record(...)`. The
-        // local result string here is only used to feed the progress
-        // monitor and emit hooks (display/telemetry), not persistence.
+        // The local `result` string is display/telemetry only; persistence
+        // (including `is_error`) flows through the `ToolCallRecord`s.
         let result: String = match emit
             .on_tool_call(
                 &tool_name,
@@ -97,31 +94,21 @@ where
             )
             .await,
         )?;
-        // Project-hook output (pre-tool gating context + post-tool side
-        // effects) accumulates in the EmitHook across the two hook calls
-        // above. Drain it now and fold it into the record the next
-        // projection reads back, so the model sees the injected context on
-        // this tool's result. The local `result` string is display-only
-        // (see comment above); persistence flows through `records`.
+        // Fold hook output into the persisted record, not the display-only
+        // `result` string: persistence flows through `records`.
         let injections = emit.drain_hook_injections();
         if !injections.is_empty() {
-            if let Some(record) = records.get_mut(records_before) {
+            if let Some(record) = records.last_mut() {
                 for injection in injections {
                     append_to_record_result(&mut record.result, &injection);
                 }
             }
         }
-        // The tool result row is persisted by the caller via
-        // record_step_tool_messages and read back by the next
-        // projection — there is no in-memory side-channel.
     }
     Ok(StepToolResults { records })
 }
 
-/// Append a project-hook injection to a persisted tool result. The result is
-/// a `serde_json::Value`: a plain string is concatenated with a blank-line
-/// separator; a structured value is coerced to its display string first, so
-/// the injected context survives projection as readable text.
+/// Append a project-hook injection to a tool result, coercing it to a string.
 fn append_to_record_result(result: &mut serde_json::Value, injection: &str) {
     let mut text = match result.as_str() {
         Some(s) => s.to_string(),


### PR DESCRIPTION
Addresses review feedback on #117 (project hooks system).

## Fixes

1. **Kill orphaned child process on timeout (blocking).** `run_hook` previously
   relied on `tokio::time::timeout(...wait_with_output())`; on timeout the
   `Child` was dropped and tokio detached the OS process, orphaning it. Set
   `Command::kill_on_drop(true)` so dropping the wait future on timeout sends
   SIGKILL — no orphaned process remains.

   _Note:_ used `kill_on_drop(true)` rather than the literal `select!` /
   `child.kill().await` from the issue because `wait_with_output()` consumes the
   child, so the literal snippet does not compile. `kill_on_drop` is the
   idiomatic fix for this exact bug and satisfies the no-orphan requirement
   while preserving `wait_with_output`'s concurrent pipe draining.

2. **Pre-tool spawn failure now blocks.** A pre-tool hook that fails to spawn
   (missing or non-executable binary) is a misconfiguration, not flakiness, so
   it now returns `PreToolOutcome::Block(...)` instead of silently continuing.
   Post-tool spawn failures remain warnings — the tool already ran. Added a
   `pre_tool_spawn_failure_blocks` test.

3. **Use `records.last_mut()`.** Replaced the `records_before` index with
   `records.last_mut()` when folding hook injections into the tool record, and
   removed the now-unused `records_before` binding.

4. **Comment hygiene.** Collapsed multi-line doc/comment blocks (module doc in
   `project_hooks.rs`, `drain_hook_injections` in `hook.rs`, and the
   hooks-related comments in `tools.rs`) to single WHY lines per the project
   comment policy.

## Verification

- `cargo build -p tenex-agent` passes.
- `cargo test -p tenex-agent` passes (including the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
