### PR TITLE
fix(agent): include Claude Code hook fields in hooks stdin payload (#121)

### DIFF
--- a/crates/tenex-agent/src/agent_bootstrap/mod.rs
+++ b/crates/tenex-agent/src/agent_bootstrap/mod.rs
@@ -405,10 +405,27 @@ pub(crate) async fn build(
         current_branch: current_branch.as_deref(),
     });
 
+    // Source the "original task" string from the conversation store: the
+    // user-role row whose `nostr_event_id` matches the conversation root
+    // event id. The conversation_id IS the root event id in our
+    // Nostr-rooted conversation model. Fallback to envelope.content if
+    // the conversation root row is not yet materialized (race or fresh
+    // conversation with no prior turn — in which case envelope.content
+    // *is* the root). Reading from storage is what fixes Bug B on
+    // delegation callbacks, where the envelope carries the delegatee's
+    // reply, not the original task.
+    let original_task: String = conv_store
+        .as_ref()
+        .and_then(|store| store.get_message_by_event(&conversation_id).ok().flatten())
+        .map(|row| row.content)
+        .unwrap_or_else(|| envelope.content.clone());
+
     // Load the workspace's project hooks (`.tenex-hooks.json`). A malformed
     // config is fatal: a broken hook file must not silently disable the
-    // gating the operator configured.
-    let project_hooks = stages::load_project_hooks(&working_dir)?;
+    // gating the operator configured. The conversation id and original task
+    // are surfaced to hooks as the Claude Code `session_id` and `prompt`.
+    let project_hooks =
+        stages::load_project_hooks(&working_dir, conversation_id.clone(), original_task.clone())?;
 
     let assembly::SupervisorComponents {
         supervisor_ref,
@@ -598,21 +615,6 @@ pub(crate) async fn build(
                 .collect::<Vec<_>>(),
         )
     };
-
-    // Source the "original task" string from the conversation store: the
-    // user-role row whose `nostr_event_id` matches the conversation root
-    // event id. The conversation_id IS the root event id in our
-    // Nostr-rooted conversation model. Fallback to envelope.content if
-    // the conversation root row is not yet materialized (race or fresh
-    // conversation with no prior turn — in which case envelope.content
-    // *is* the root). Reading from storage is what fixes Bug B on
-    // delegation callbacks, where the envelope carries the delegatee's
-    // reply, not the original task.
-    let original_task: String = conv_store
-        .as_ref()
-        .and_then(|store| store.get_message_by_event(&conversation_id).ok().flatten())
-        .map(|row| row.content)
-        .unwrap_or_else(|| envelope.content.clone());
 
     let execution_id =
         std::env::var("TENEX_EXECUTION_ID").unwrap_or_else(|_| format!("local-{}", std::process::id()));

--- a/crates/tenex-agent/src/agent_bootstrap/stages.rs
+++ b/crates/tenex-agent/src/agent_bootstrap/stages.rs
@@ -280,6 +280,8 @@ pub(super) fn open_conversation_store(
 /// hook file must not silently disable gating the operator configured.
 pub(super) fn load_project_hooks(
     working_dir: &str,
+    session_id: String,
+    prompt: String,
 ) -> anyhow::Result<Option<Arc<crate::project_hooks::ProjectHooksRunner>>> {
     use anyhow::Context as _;
     let dir = std::path::Path::new(working_dir);
@@ -291,6 +293,8 @@ pub(super) fn load_project_hooks(
     Ok(Some(Arc::new(crate::project_hooks::ProjectHooksRunner::new(
         config,
         dir.to_path_buf(),
+        session_id,
+        prompt,
     ))))
 }
 

--- a/crates/tenex-agent/src/project_hooks.rs
+++ b/crates/tenex-agent/src/project_hooks.rs
@@ -138,13 +138,25 @@ pub enum PreToolOutcome {
 pub struct ProjectHooksRunner {
     hooks: Vec<HookEntry>,
     working_dir: PathBuf,
+    /// Conversation id, surfaced to hooks as the Claude Code `session_id`.
+    session_id: String,
+    /// The conversation's root user message, surfaced to hooks as the Claude
+    /// Code `prompt`. Stable across re-engagements within the conversation.
+    prompt: String,
 }
 
 impl ProjectHooksRunner {
-    pub fn new(config: ProjectHooksConfig, working_dir: PathBuf) -> Self {
+    pub fn new(
+        config: ProjectHooksConfig,
+        working_dir: PathBuf,
+        session_id: String,
+        prompt: String,
+    ) -> Self {
         Self {
             hooks: config.hooks,
             working_dir,
+            session_id,
+            prompt,
         }
     }
 
@@ -152,7 +164,7 @@ impl ProjectHooksRunner {
     /// blocks the tool call. Hooks that exit 0 with stdout contribute an
     /// injection. A hook that times out is treated as non-blocking.
     pub async fn fire_pre_tool(&self, tool_name: &str, args_json: &str) -> PreToolOutcome {
-        let stdin = pre_tool_stdin(tool_name, args_json);
+        let stdin = self.pre_tool_stdin(tool_name, args_json);
         let mut injections = Vec::new();
         for hook in self.hooks.iter().filter(|h| h.subscribes_to(HookEvent::PreTool)) {
             match self.run_hook(hook, &stdin).await {
@@ -203,7 +215,7 @@ impl ProjectHooksRunner {
         args_json: &str,
         result: &str,
     ) -> Vec<String> {
-        let stdin = post_tool_stdin(tool_name, args_json, result);
+        let stdin = self.post_tool_stdin(tool_name, args_json, result);
         let mut injections = Vec::new();
         for hook in self.hooks.iter().filter(|h| h.subscribes_to(HookEvent::PostTool)) {
             match self.run_hook(hook, &stdin).await {
@@ -286,6 +298,41 @@ impl ProjectHooksRunner {
             Err(_) => HookRun::TimedOut,
         }
     }
+
+    /// Build the `pre-tool` stdin payload. `args_json` is the tool's argument
+    /// string; it is embedded as parsed JSON when valid, else as a JSON string.
+    /// The `session_id`, `cwd`, `transcript_path`, and `prompt` fields make the
+    /// payload Claude Code-compatible; `transcript_path` is always `null`
+    /// because TENEX persists transcripts in SQLite, not a JSONL file.
+    fn pre_tool_stdin(&self, tool_name: &str, args_json: &str) -> String {
+        let payload = serde_json::json!({
+            "event": HookEvent::PreTool.wire_name(),
+            "tool": tool_name,
+            "args": parse_args(args_json),
+            "session_id": self.session_id,
+            "cwd": self.working_dir.to_string_lossy(),
+            "transcript_path": serde_json::Value::Null,
+            "prompt": self.prompt,
+        });
+        payload.to_string()
+    }
+
+    /// Build the `post-tool` stdin payload, carrying the tool's textual result
+    /// alongside the same Claude Code-compatible fields as the `pre-tool`
+    /// payload.
+    fn post_tool_stdin(&self, tool_name: &str, args_json: &str, result: &str) -> String {
+        let payload = serde_json::json!({
+            "event": HookEvent::PostTool.wire_name(),
+            "tool": tool_name,
+            "args": parse_args(args_json),
+            "result": result,
+            "session_id": self.session_id,
+            "cwd": self.working_dir.to_string_lossy(),
+            "transcript_path": serde_json::Value::Null,
+            "prompt": self.prompt,
+        });
+        payload.to_string()
+    }
 }
 
 /// Internal result of running one hook process.
@@ -297,28 +344,6 @@ enum HookRun {
     },
     TimedOut,
     SpawnFailed(String),
-}
-
-/// Build the `pre-tool` stdin payload. `args_json` is the tool's argument
-/// string; it is embedded as parsed JSON when valid, else as a JSON string.
-fn pre_tool_stdin(tool_name: &str, args_json: &str) -> String {
-    let payload = serde_json::json!({
-        "event": HookEvent::PreTool.wire_name(),
-        "tool": tool_name,
-        "args": parse_args(args_json),
-    });
-    payload.to_string()
-}
-
-/// Build the `post-tool` stdin payload, carrying the tool's textual result.
-fn post_tool_stdin(tool_name: &str, args_json: &str, result: &str) -> String {
-    let payload = serde_json::json!({
-        "event": HookEvent::PostTool.wire_name(),
-        "tool": tool_name,
-        "args": parse_args(args_json),
-        "result": result,
-    });
-    payload.to_string()
 }
 
 /// Parse a tool's argument string into JSON. A non-JSON string is wrapped as a
@@ -402,7 +427,12 @@ mod tests {
                 events: vec![HookEvent::PreTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
 
         let blocked = runner.fire_pre_tool("shell", r#"{"command":"ls"}"#).await;
         // The block reason must surface the hook's stderr, not a generic
@@ -426,7 +456,12 @@ mod tests {
                 events: vec![HookEvent::PreTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         match runner.fire_pre_tool("shell", "{}").await {
             PreToolOutcome::Block(reason) => assert!(reason.contains("silent-block")),
             other => panic!("expected block, got {other:?}"),
@@ -443,7 +478,12 @@ mod tests {
                 events: vec![HookEvent::PreTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         match runner.fire_pre_tool("shell", "{}").await {
             PreToolOutcome::Block(reason) => assert!(reason.contains("missing")),
             other => panic!("expected block, got {other:?}"),
@@ -460,7 +500,12 @@ mod tests {
                 events: vec![HookEvent::PreTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         let outcome = runner.fire_pre_tool("fs_read", r#"{"path":"a"}"#).await;
         assert_eq!(
             outcome,
@@ -480,7 +525,12 @@ mod tests {
                 events: vec![HookEvent::PostTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         let injections = runner
             .fire_post_tool("fs_read", r#"{"path":"a"}"#, "file contents")
             .await;
@@ -497,7 +547,12 @@ mod tests {
                 events: vec![HookEvent::PostTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         let injections = runner.fire_post_tool("fs_read", "{}", "ok").await;
         assert!(injections.is_empty());
     }
@@ -514,7 +569,12 @@ mod tests {
                 events: vec![HookEvent::PreTool],
             }],
         };
-        let runner = ProjectHooksRunner::new(config, tmp.path().to_path_buf());
+        let runner = ProjectHooksRunner::new(
+            config,
+            tmp.path().to_path_buf(),
+            "test-session".into(),
+            "test prompt".into(),
+        );
         let outcome = runner.fire_pre_tool("shell", r#"{"command":"ls"}"#).await;
         let PreToolOutcome::Continue { injections } = outcome else {
             panic!("expected continue");
@@ -523,5 +583,12 @@ mod tests {
         assert_eq!(payload["event"], "pre-tool");
         assert_eq!(payload["tool"], "shell");
         assert_eq!(payload["args"]["command"], "ls");
+        // Claude Code-compatible fields must be present so tools like
+        // proactive-context can read them. `transcript_path` is always null
+        // because TENEX stores transcripts in SQLite, not a JSONL file.
+        assert_eq!(payload["session_id"], "test-session");
+        assert_eq!(payload["cwd"], tmp.path().to_string_lossy().as_ref());
+        assert_eq!(payload["transcript_path"], serde_json::Value::Null);
+        assert_eq!(payload["prompt"], "test prompt");
     }
 }


### PR DESCRIPTION
## Summary

Closes #121. Project hooks fired at pre/post-tool boundaries previously emitted only TENEX-specific fields (`event`, `tool`, `args`, `result`). Claude Code-compatible tools such as `proactive-context` expect `session_id`, `cwd`, `transcript_path`, and `prompt` — without them they received malformed input and produced no output.

## Changes

- `crates/tenex-agent/src/project_hooks.rs`
  - `ProjectHooksRunner` gains `session_id` (the conversation id) and `prompt` (the conversation's root user message) fields; `::new` takes both.
  - Both the pre-tool and post-tool stdin payloads now include `session_id`, `cwd` (from the runner's `working_dir`), `transcript_path` (always `null` — TENEX stores transcripts in SQLite, not JSONL), and `prompt`. `result` remains post-tool only.
  - The two stdin builders moved onto the runner as methods so they read these fields directly.
- `crates/tenex-agent/src/agent_bootstrap/stages.rs` — `load_project_hooks` threads `session_id` and `prompt` into `ProjectHooksRunner::new`.
- `crates/tenex-agent/src/agent_bootstrap/mod.rs` — the `original_task` derivation is hoisted above the hook runner construction so a single source of truth feeds both the hook `prompt` and the `AgentBootstrap` field. `conversation_id` supplies `session_id`.

## Validation

- `cargo build -p tenex-agent` — clean
- `cargo test -p tenex-agent` — 58 + 12 hook tests pass; the `hook_receives_parsed_args_on_stdin` test now asserts `session_id`, `cwd`, `transcript_path` (null), and `prompt`.
- End-to-end: `proactive-context awareness --hook PostToolUse` returns a non-empty `hookSpecificOutput` when fed the new payload shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)